### PR TITLE
Bump package to v1.0 and update version history/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ it. What changes is how this side is installed and driven.
 | [`doc/DATA_CONTRACT.md`](doc/DATA_CONTRACT.md) | Normative format of every generated file |
 | [`doc/POLICY.md`](doc/POLICY.md) | Implementation rules a change is judged against |
 | [`doc/DEPLOYMENT.md`](doc/DEPLOYMENT.md) | Installing, operating and diagnosing the pipeline |
-| [`doc/MODERNIZATION_PLAN.md`](doc/MODERNIZATION_PLAN.md) | The survey and plan behind the 2.0 rewrite |
+| [`doc/MODERNIZATION_PLAN.md`](doc/MODERNIZATION_PLAN.md) | The survey and plan behind the modernization |
 | [`doc/VERSIONS`](doc/VERSIONS) | Release history of the repository |
 | [`doc/LICENSE.md`](doc/LICENSE.md) | The license, with the full texts beside it |
 

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -1,8 +1,8 @@
 finance Repository Version History
 ==================================
 
-v2.0.1 (Release Date: TBD)
---------------------------
+v1.0 (2026-08-14)
+-----------------
 - Declare the repository dual licensed under the GPL version 3 or the LGPL
   version 3, adding doc/LICENSE.md, doc/COPYING and doc/COPYING.LESSER, the
   license field of pyproject.toml, and the license line of every module header.
@@ -10,13 +10,11 @@ v2.0.1 (Release Date: TBD)
   of doc/MODERNIZATION_PLAN.md resolved, keeping the earlier text as the record
   of why the modernization added none.
 - Start file level version management at v1.0 for every module, renumbering the
-  single v2.0 entry each header carried and leaving its description unchanged.
+  single modernization entry each header carried and leaving its description
+  unchanged.
 - State the module header order in doc/POLICY.md section 2.7, including the
   license line and what a Description is required to establish.
 - Add this file, and link the license and history documents from README.md.
-
-v2.0 (2026-08-14)
------------------
 - Restructure the repository as an installable Python package with a one-way
   dependency direction, replacing the sys.path manipulation that let bin/
   import lib/. test/test_package.py asserts the direction against the source.
@@ -47,10 +45,10 @@ v2.0 (2026-08-14)
 - Add doc/REQUIREMENTS.md, doc/BASIC_DESIGN.md, doc/DATA_CONTRACT.md,
   doc/POLICY.md, doc/DEPLOYMENT.md and doc/MODERNIZATION_PLAN.md.
 
-Before v2.0
+Before v1.0
 -----------
 - The repository carries no release tag and no version file for any revision
-  before v2.0, so no earlier version number is recorded here. The work of that
+  before v1.0, so no earlier version number is recorded here. The work of that
   period survives as a numbered commit series ending at "323 Correspond to 10
   days off", and the commit log is its only history. Nothing has been
   reconstructed from it into a version entry.

--- a/finance/__init__.py
+++ b/finance/__init__.py
@@ -32,7 +32,7 @@
 
 import logging
 
-__version__ = "2.0.0"
+__version__ = "1.0.0"
 
 LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "finance"
-version = "2.0.0"
+version = "1.0.0"
 description = "Batch pipeline producing technical analysis data and charts for finance-dashboard"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
### Motivation
- Publish an initial `v1.0` release and align package metadata and module headers with that release intent.
- Record the release and housekeeping changes in the repository history so downstream consumers and installers see a coherent version entry in `doc/VERSIONS`.
- Tidy a small README line to reflect the renamed/streamlined modernization document title.

### Description
- Set the package version in `pyproject.toml` to `1.0.0` by changing the `version` field to `"1.0.0"`.
- Update the package `__version__` in `finance/__init__.py` to `"1.0.0"` and adjust the header entry to match the new release line.
- Replace and reorganize `doc/VERSIONS` to add a `v1.0 (2026-08-14)` section and rename the historical headings to reflect the new baseline.
- Edit `README.md` to change the `doc/MODERNIZATION_PLAN.md` description text to the shorter "modernization" phrasing.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e847a75f8832295a3d5dfce1ab8f7)