### PR TITLE
Bump package version to 1.0.1 and synchronize module headers

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -59,9 +59,8 @@
 #  - 127: A required command is missing.
 #
 #  Version History:
-#  v1.1 2026-08-14
-#       Create the environment file the API key is kept in.
 #  v1.0 2026-08-14
+#       Create the environment file the API key is kept in.
 #       Install a package into a virtual environment instead of copying
 #       bin/ and lib/.
 #

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -1,8 +1,8 @@
 finance Repository Version History
 ==================================
 
-v1.1 (Release Date: TBD)
-------------------------
+v1.0.1 (Release Date: TBD)
+--------------------------
 - Replace Yahoo Finance with the J-Quants API v2 Free plan as the price source.
   finance/datasources/yahoo.py and the yfinance dependency are removed, and
   nothing in the package reaches an unofficial endpoint or parses a web page for

--- a/finance/__init__.py
+++ b/finance/__init__.py
@@ -25,16 +25,15 @@
 #  - Standard library only
 #
 #  Version History:
-#  v1.1 2026-08-14
-#       Quiet the HTTP client's own loggers along with the rest.
 #  v1.0 2026-08-14
+#       Quiet the HTTP client's own loggers along with the rest.
 #       Restructure the repository as an installable package.
 #
 ########################################################################
 
 import logging
 
-__version__ = "1.1.0"
+__version__ = "1.0.1"
 
 LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"

--- a/finance/analysis.py
+++ b/finance/analysis.py
@@ -41,10 +41,9 @@
 #  - NumPy, pandas
 #
 #  Version History:
-#  v1.1 2026-08-14
+#  v1.0 2026-08-14
 #       Fetch within the plan window and report the latest trading day
 #       a run covered.
-#  v1.0 2026-08-14
 #       Separate the pipeline from file paths, the data source and the
 #       command line.
 #

--- a/finance/cli/charts.py
+++ b/finance/cli/charts.py
@@ -64,10 +64,9 @@
 #  - See pyproject.toml
 #
 #  Version History:
-#  v1.1 2026-08-14
+#  v1.0 2026-08-14
 #       Build the J-Quants source from the settings and record where the
 #       data came from.
-#  v1.0 2026-08-14
 #       Replace optparse, honour -u, and call the shared pipeline.
 #
 ########################################################################

--- a/finance/config.py
+++ b/finance/config.py
@@ -86,10 +86,9 @@
 #  - PyYAML
 #
 #  Version History:
-#  v1.1 2026-08-14
+#  v1.0 2026-08-14
 #       Add the J-Quants settings and the plan window, and make the
 #       start date default to what the plan offers.
-#  v1.0 2026-08-14
 #       Initial release.
 #
 ########################################################################

--- a/finance/datasources/__init__.py
+++ b/finance/datasources/__init__.py
@@ -31,10 +31,9 @@
 #  - pandas
 #
 #  Version History:
-#  v1.1 2026-08-14
+#  v1.0 2026-08-14
 #       Replace the Yahoo Finance source with J-Quants and take the
 #       settings the source is built from.
-#  v1.0 2026-08-14
 #       Initial release, replacing the direct pandas-datareader and HTML
 #       scraping calls.
 #

--- a/finance/errors.py
+++ b/finance/errors.py
@@ -32,10 +32,9 @@
 #  - Standard library only
 #
 #  Version History:
-#  v1.1 2026-08-14
+#  v1.0 2026-08-14
 #       Add the authentication, rate limit, unavailable dataset and
 #       invalid code errors the J-Quants adapter distinguishes.
-#  v1.0 2026-08-14
 #       Initial release.
 #
 ########################################################################

--- a/finance/reporting.py
+++ b/finance/reporting.py
@@ -24,9 +24,8 @@
 #  - pandas
 #
 #  Version History:
-#  v1.1 2026-08-14
-#       Measure staleness against the newest date the plan publishes.
 #  v1.0 2026-08-14
+#       Measure staleness against the newest date the plan publishes.
 #       Separate the summary pipeline from the command line.
 #
 ########################################################################

--- a/finance/stocklist.py
+++ b/finance/stocklist.py
@@ -33,9 +33,8 @@
 #  - Standard library only
 #
 #  Version History:
-#  v1.1 2026-08-14
-#       Drop the market index codes along with the index data source.
 #  v1.0 2026-08-14
+#       Drop the market index codes along with the index data source.
 #       Replace the pandas based reader with a plain CSV reader.
 #
 ########################################################################

--- a/finance/storage.py
+++ b/finance/storage.py
@@ -30,10 +30,9 @@
 #  - pandas
 #
 #  Version History:
-#  v1.1 2026-08-14
+#  v1.0 2026-08-14
 #       Add data_source.txt, which states where the generated data came
 #       from and how old it is.
-#  v1.0 2026-08-14
 #       Centralize file access and separate model persistence from
 #       fitting.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "finance"
-version = "1.1.0"
+version = "1.0.1"
 description = "Personal batch pipeline producing technical analysis data and charts for finance-dashboard"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/run.sh
+++ b/run.sh
@@ -64,10 +64,9 @@
 #  - 1: At least one step failed.
 #
 #  Version History:
-#  v1.1 2026-08-14
+#  v1.0 2026-08-14
 #       Read the API key from an environment file and check that step 1
 #       has one before the job starts.
-#  v1.0 2026-08-14
 #       Rewrite for POSIX sh, report failures, and drop the Ruby mailer.
 #
 ########################################################################

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,10 +28,9 @@
 #  - pandas, pytest
 #
 #  Version History:
-#  v1.1 2026-08-14
+#  v1.0 2026-08-14
 #       Give the settings fixture a plan window and record where the
 #       price fixture came from.
-#  v1.0 2026-08-14
 #       Initial release.
 #
 ########################################################################

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -40,9 +40,8 @@
 #  - pandas, pytest
 #
 #  Version History:
-#  v1.1 2026-08-14
-#       Cover the recorded data source and the API key requirement.
 #  v1.0 2026-08-14
+#       Cover the recorded data source and the API key requirement.
 #       Initial release.
 #
 ########################################################################

--- a/test/test_contract.py
+++ b/test/test_contract.py
@@ -52,10 +52,9 @@
 #  - pandas, pytest
 #
 #  Version History:
-#  v1.1 2026-08-14
+#  v1.0 2026-08-14
 #       Pin data_source.txt, which tells the dashboard how old the data
 #       it is showing is.
-#  v1.0 2026-08-14
 #       Initial release.
 #
 ########################################################################

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -44,9 +44,8 @@
 #  - pytest
 #
 #  Version History:
-#  v1.1 2026-08-14
-#       Guard the data source decision and the API key.
 #  v1.0 2026-08-14
+#       Guard the data source decision and the API key.
 #       Initial release.
 #
 ########################################################################


### PR DESCRIPTION
### Motivation
- Align the package metadata and in-package version identifiers so release and documentation agree on the new patch release `1.0.1`.
- Keep the human-readable `doc/VERSIONS` and the file header `Version History` comments consistent with the packaged version.

### Description
- Update `pyproject.toml` to set the project `version` to `1.0.1`.
- Set `__version__` in `finance/__init__.py` to `"1.0.1"` to match the packaged version.
- Normalize `Version History` comment headers across many modules (downgrade `v1.1` markers to `v1.0` where appropriate) and adjust a few header lines in `deploy.sh`/`run.sh` for clarity.
- Update `doc/VERSIONS` top entry to `v1.0.1` and adjust the release note placement accordingly.

### Testing
- Ran the test suite with `pytest` and all tests completed successfully (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ed3a9bab48322aa52d328a65839b9)