### PR TITLE
Remove references to sibling repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,10 +790,8 @@ For full details, please refer to [`doc/LICENSE.md`](doc/LICENSE.md). See also
 [`doc/COPYING`](doc/COPYING) and [`doc/COPYING.LESSER`](doc/COPYING.LESSER) for
 the complete license texts.
 
-The same terms apply to the sibling repositories `finance-dashboard` and
-`reply-writer`, so the three are consistent. `pyproject.toml` carries the
-matching `license` field, and every source module repeats the terms in its
-header block.
+`pyproject.toml` carries the matching `license` field, and every source module
+repeats the terms in its header block.
 
 Third-party components keep their own licenses. This repository bundles none;
 its dependencies are installed from PyPI and are listed in `pyproject.toml`.

--- a/doc/MODERNIZATION_PLAN.md
+++ b/doc/MODERNIZATION_PLAN.md
@@ -564,10 +564,8 @@ the record of why the plan itself added no license.
 
 The repository has never contained a `LICENSE`, `COPYING` or any license header,
 in any commit reachable in its history. `README.md` states none, and
-`pyproject.toml` did not exist. The sibling repositories `finance-dashboard` and
-`reply-writer` are both dual licensed GPL-3.0-or-later or LGPL-3.0-or-later and
-carry the texts under `doc/`, which suggests the same intent here — but that is
-an inference about the author's wishes, not a fact recorded in this repository.
+`pyproject.toml` did not exist. No license intent was therefore recorded in this
+repository.
 
 Choosing a license is the copyright holder's decision and is out of scope for a
 modernization. `pyproject.toml` therefore carries **no** `license` field, and no

--- a/doc/POLICY.md
+++ b/doc/POLICY.md
@@ -223,8 +223,8 @@ A change is judged by:
   inside each pair of quotes. A longer one opens on the line after the quotes
   and describes the non-obvious parameters under `Args:`, the result under
   `Returns:` and the failures under `Raises:`.
-- Prefer `str.format()` over an f-string. This is a house convention shared with
-  the sibling repositories; ruff's `UP030` and `UP032` are disabled for it.
+- Prefer `str.format()` over an f-string. This is the repository's convention;
+  ruff's `UP030` and `UP032` are disabled for it.
 
 ### 2.2 Program Structure
 
@@ -353,8 +353,7 @@ recipient's option. The texts are [`COPYING`](COPYING) and
 [`COPYING.LESSER`](COPYING.LESSER), and [`LICENSE.md`](LICENSE.md) states the
 choice. This settles what earlier revisions of this document and of
 [`MODERNIZATION_PLAN.md`](MODERNIZATION_PLAN.md) recorded as an open item for the
-copyright holder; the decision came from the copyright holder, not from an
-inference drawn across the sibling repositories.
+copyright holder; the decision came from the copyright holder.
 
 - Every source module carries the line
   `License: The GPL version 3, or LGPL version 3 (Dual License).` in its header

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ target-version = "py311"
 select = ["E", "F", "I", "W", "UP", "B"]
 ignore = [
     # The encoding declaration and str.format() over f-strings are the
-    # house style shared with the sibling repositories, not oversights.
+    # repository's established style, not oversights.
     "UP009",
     "UP030",
     "UP032",


### PR DESCRIPTION
### Motivation

- Make the repository documentation and configuration self-contained by removing statements that refer to or infer licensing/house-style consistency with sibling repositories.
- Avoid suggesting cross-repository licensing intent or shared policy decisions that are not recorded in this repository itself.

### Description

- Remove the explicit mention of `finance-dashboard` and `reply-writer` from the README so the license section refers only to this repository.
- Rephrase the ruff justification in `pyproject.toml` to attribute the style to this repository rather than to sibling repositories.
- Update `doc/POLICY.md` to remove language inferring policy decisions from other repositories and to state conventions as repository-local.
- Edit `doc/MODERNIZATION_PLAN.md` to remove cross-repository license inference and record that no license intent was recorded in this repository.

### Testing

- Ran `PYTHONPATH=. pytest`, which completed successfully with `456 passed, 2 deselected` and one non-failing pandas warning.
- Ran `pytest` without adjusting `PYTHONPATH`, which failed with `ModuleNotFoundError: No module named 'finance'` because the package was not on the import path.
- Attempted to run `.venv/bin/pytest` but the local virtual environment binary was not present, so that invocation did not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7eda33002c83228e2029372e91c548)