### PR TITLE
Reject J-Quants rows missing required adjusted fields and add test

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -11,7 +11,8 @@ v1.0.1 (Release Date: TBD)
   URL, /equities/bars/daily, pagination, the request interval, retries,
   timeouts, HTTP status handling, the abbreviated v2 field names and the five
   character stock code form, and lets none of them out. The analysis layer
-  receives the same six column frame it always did.
+  receives the same six column frame it always did. Refuse a response when any
+  row is missing a required field, reporting the provider error consistently.
 - Take all six canonical columns from the adjusted series, so that candlesticks
   and indicators sit on one basis for the first time. No formula changed; the
   contract test still regenerates all 42 computed columns of the committed

--- a/finance/datasources/jquants.py
+++ b/finance/datasources/jquants.py
@@ -62,7 +62,8 @@
 #
 #  Version History:
 #  v1.0 2026-08-14
-#       Initial release, replacing the Yahoo Finance adapter.
+#       Initial release, replacing the Yahoo Finance adapter. Refuse a
+#       missing required field in any response row.
 #
 ########################################################################
 
@@ -203,12 +204,15 @@ def normalize(rows: list[dict[str, Any]], code: str) -> pd.DataFrame:
         return pd.DataFrame(columns=list(CANONICAL_COLUMNS))
 
     required = {DATE_FIELD, *FIELD_MAP.values()}
-    missing = sorted(required.difference(rows[0]))
-    if missing:
-        raise DataSourceError(
-            "Response for {0} is missing {1}. Adjusted prices are required and are "
-            "not substituted from the unadjusted fields.".format(code, ", ".join(missing))
-        )
+    for row_number, row in enumerate(rows, start=1):
+        missing = sorted(required.difference(row))
+        if missing:
+            raise DataSourceError(
+                "Response row {0} for {1} is missing {2}. Adjusted prices are required and "
+                "are not substituted from the unadjusted fields.".format(
+                    row_number, code, ", ".join(missing)
+                )
+            )
 
     index = pd.to_datetime([row[DATE_FIELD] for row in rows], errors="coerce")
     if index.hasnans:

--- a/test/test_datasources.py
+++ b/test/test_datasources.py
@@ -24,6 +24,7 @@
 #  - Every column is taken from the adjusted series.
 #  - A response without the adjusted fields is refused, not filled from
 #    the unadjusted ones.
+#  - A required field missing from a later response row is refused.
 #  - Dates are parsed, sorted, deduplicated and reindexed to business
 #    days, and carry no timezone.
 #  - A null figure becomes a gap rather than a zero.
@@ -52,7 +53,8 @@
 #
 #  Version History:
 #  v1.0 2026-08-14
-#       Initial release, replacing the Yahoo adapter tests.
+#       Initial release, replacing the Yahoo adapter tests. Cover a
+#       required field missing from a later response row.
 #
 ########################################################################
 
@@ -215,6 +217,14 @@ def test_a_response_without_the_adjusted_fields_is_refused():
             if not key.startswith("Adj")}
     with pytest.raises(DataSourceError, match="AdjC"):
         normalize([bare], "7203")
+
+
+def test_a_required_field_missing_from_a_later_row_is_refused():
+    response_rows = rows()
+    del response_rows[1]["AdjC"]
+
+    with pytest.raises(DataSourceError, match=r"row 2.*AdjC"):
+        normalize(response_rows, "7203")
 
 
 def test_the_index_is_sorted_naive_and_on_business_days():


### PR DESCRIPTION
### Motivation

- Ensure the adapter never silently substitutes unadjusted values by refusing any API response row that lacks required adjusted fields and reporting the offending row consistently.
- Record this behavioral change in the repository `doc/VERSIONS` so the release notes reflect the stricter validation.

### Description

- Update `finance/datasources/jquants.py` `normalize` function to iterate over all response rows, detect missing required fields per-row, and raise `DataSourceError` with the row number and missing fields instead of only inspecting the first row.
- Adjust the module version/history comment to document the new refusal behavior for missing required fields.
- Update `doc/VERSIONS` to mention that responses are refused when any row is missing a required field and that an error is reported consistently.
- Add a unit test `test_a_required_field_missing_from_a_later_row_is_refused` to `test/test_datasources.py` that deletes an adjusted field from a later row and asserts that `normalize` raises `DataSourceError` with a message referencing the specific row.

### Testing

- Ran the modified datasources unit tests with `pytest test/test_datasources.py`, including `test_a_required_field_missing_from_a_later_row_is_refused`, and they passed.
- The updated datasource normalization behavior is covered by the new test and the existing datasources tests that validate canonical columns, date handling, gaps, pagination, and error cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7efc5358508322a564db7897811198)