### PR TITLE
Skip CI for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,13 @@ name: CI
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - '**/*.md'
+      - 'doc/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'doc/**'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
Updated the CI workflow to skip running tests when only documentation files are modified, reducing unnecessary CI runs and improving development efficiency.

## Key Changes
- Added `paths-ignore` configuration to the `push` trigger to exclude markdown files and the `doc/` directory
- Added `paths-ignore` configuration to the `pull_request` trigger with the same exclusions
- This prevents CI jobs from running when changes are limited to `**/*.md` files or anything in the `doc/` directory

## Details
The workflow will now only execute when changes are made to non-documentation files. This is particularly useful for:
- Reducing CI resource usage and feedback time for documentation-only PRs
- Allowing documentation updates to be merged without waiting for full test suite completion
- Maintaining a cleaner CI history by avoiding runs that don't test actual code changes

https://claude.ai/code/session_015g5cnn9nyj6oU5gbhX3SVz