### PR TITLE
Clarify VERSIONS policy for pre-release repositories

### DIFF
--- a/doc/POLICY.md
+++ b/doc/POLICY.md
@@ -393,6 +393,13 @@ not a list of the functions below it, which the code already carries.
   what accumulated in it is known; which number it takes is decided then.
 - Replacing `TBD` with the actual release date is the release itself, not a
   change to record in the entry.
+- A repository that has not yet made its first release is in its initial
+  construction stage, and that stage takes no entry here. Typically this is the
+  state while `v1.0` is the first release and the repository still stands below
+  it, or `v1.0` itself is unreleased. The changes made while building up to that
+  release are not accumulated in `doc/VERSIONS` one by one: the file is the
+  record of released versions, not of the construction that precedes the first
+  of them, and its first entry is written when that release is made.
 - A documentation-only change takes no `doc/VERSIONS` entry, unless its scale
   makes it worth one line saying so.
 - The version declared in `pyproject.toml`, the one exposed as


### PR DESCRIPTION
This change clarifies the documentation policy for repositories that have not yet made their first release.

**Summary**
Added guidance to `doc/POLICY.md` explaining how the `doc/VERSIONS` file should be handled during a project's initial construction phase, before the first release is made.

**Key Changes**
- Documented that repositories in their initial construction stage (typically before `v1.0` is released) should not have entries in `doc/VERSIONS`
- Clarified that `doc/VERSIONS` is a record of released versions, not of the development work leading up to the first release
- Specified that the first entry in `doc/VERSIONS` is written when the first release is made, not during the pre-release development phase

**Details**
This policy clarification helps maintainers understand that accumulating changes in `doc/VERSIONS` before any release has been made is not necessary or appropriate. The file's purpose is to document released versions and their changes, so the first entry should correspond to the first actual release.

https://claude.ai/code/session_014Q4JqJ59yu41uBmxVngoVj