### PR TITLE
Preserve last valid summary and fail when no stock can be aggregated

### DIFF
--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -39,6 +39,7 @@ v1.0.1 (Release Date: TBD)
   written.
 - Source the API key from a root-only environment file created by deploy.sh and
   checked by run.sh before the job starts, and leave it empty in CI.
+- Preserve the last valid summary and fail when no stock can be aggregated.
 
 v1.0 (2026-08-14)
 -----------------

--- a/finance/reporting.py
+++ b/finance/reporting.py
@@ -24,6 +24,8 @@
 #  - pandas
 #
 #  Version History:
+#  v1.1 2026-08-19
+#       Preserve the last valid summary when no stock can be aggregated.
 #  v1.0 2026-08-14
 #       Measure staleness against the newest date the plan publishes.
 #       Separate the summary pipeline from the command line.
@@ -41,6 +43,7 @@ from finance import storage
 from finance.aggregation import DEFAULT_SORT_KEY, Aggregator
 from finance.analysis import load_indicator_frames
 from finance.config import Settings
+from finance.errors import DataFormatError
 from finance.stocklist import read_stock_list
 
 logger = logging.getLogger(__name__)
@@ -87,8 +90,9 @@ def build_summary(
     Raises:
         StorageError: The stock list or the output cannot be read or
             written.
-        DataFormatError: The stock list is malformed, or the sort key
-            names a column the layout has not got.
+        DataFormatError: The stock list is malformed, the sort key
+            names a column the layout has not got, or no stock can be
+            summarized.
     """
     when = today or date.today()
     list_path = settings.data_file(request.stock_list)
@@ -109,6 +113,8 @@ def build_summary(
         screening_key=request.screening_key,
         as_of=as_of,
     )
+    if table.empty:
+        raise DataFormatError("No stock had data recent enough to summarize")
 
     output_path = settings.data_file(request.output)
     storage.write_summary_csv(table, output_path)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -255,6 +255,22 @@ def test_summary_history_writes_a_dated_copy(tmp_path, monkeypatch, indicator_fi
     assert len(copies) == 1
 
 
+def test_empty_summary_preserves_the_last_output(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "out"
+    data_dir.mkdir()
+    (data_dir / "stocks.txt").write_text("7203,トヨタ\n", encoding="utf-8")
+    output = data_dir / "summary.csv"
+    previous = "Code\tName\n7203\tトヨタ\n"
+    output.write_text(previous, encoding="utf-8")
+
+    status = summary_cli.main(["-o", "summary.csv", "-y", "--data-dir", str(data_dir)])
+
+    assert status == EXIT_FAILURE
+    assert output.read_text(encoding="utf-8") == previous
+    assert not (data_dir / "history").exists()
+
+
 def test_charts_records_the_data_source_when_it_updates(tmp_path, monkeypatch, raw_prices):
     monkeypatch.chdir(tmp_path)
     data_dir = tmp_path / "out"


### PR DESCRIPTION
### Motivation
- Avoid overwriting a previously generated summary with an empty output when no stocks have recent enough data to summarize.
- Make the summary pipeline explicit about this failure mode so callers can preserve and inspect the last valid report.

### Description
- Added a check in `finance/reporting.py::build_summary` to raise `DataFormatError` when the aggregated `table` is empty, preventing an empty summary from being written.
- Imported `DataFormatError` from `finance.errors` and updated the function docstring to document the new error condition.
- Updated history/version notes in `finance/reporting.py` and `doc/VERSIONS` to record the behavior change.
- Added `test_empty_summary_preserves_the_last_output` to `test/test_cli.py` to assert the CLI returns failure and the existing summary file is preserved when no stock can be aggregated.

### Testing
- Ran the automated test suite with the updated tests, including `test/test_cli.py::test_empty_summary_preserves_the_last_output`, and the run completed successfully.
- The new test verifies that an existing `summary.csv` is not overwritten and that no history file is created when aggregation yields no rows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a85913207188322ad9d93bcccd04776)