### PR TITLE
docs: resolve remaining documentation consistency issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ The system is built around those configured limits:
 Earlier versions charted reference market indices. The migration history
 and the exact historical set are recorded in
 [`doc/JQUANTS_MIGRATION.md`](doc/JQUANTS_MIGRATION.md#6-what-was-withdrawn-rather-than-replaced).
-The Free plan carries no index
-values, and no free, licensed, machine-readable alternative has been
-adopted, so the capability is withdrawn rather than replaced. Nothing in the
-analysis of Japanese equities depends on a reference index: no indicator,
-summary, screening or model takes one as an input.
+No index dataset has been adopted for the current pipeline, and no free,
+licensed, machine-readable alternative source has been adopted, so the
+capability remains withdrawn. Nothing in the analysis of Japanese equities
+depends on a reference index: no indicator, summary, screening or model takes
+one as an input.
 
 "Not obtainable on acceptable terms, therefore not provided" is a legitimate
 outcome, and a better one than an index of uncertain provenance.
@@ -182,7 +182,7 @@ TA-Lib C library first and let pip build the extension against it.
 
 There is no `requirements.txt`. Dependencies are declared in `pyproject.toml`
 and are installed by `pip install .`; see
-[Migrating from the previous version](#11-migrating-from-the-previous-version).
+[Migrating from the previous version](#14-migrating-from-the-previous-version).
 
 ---
 

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -42,11 +42,12 @@ jquants:
   # plan's rate limit is exceeded, and a run over a stock list is in no
   # hurry, so it paces itself rather than finding the limit.
   request_interval: 1.0
-  # How many days behind today the newest row of the plan is. The Free
-  # plan publishes twelve weeks in arrears; a paid plan sets this to 0.
+  # Program defaults for the configured publication and retention window.
+  # Check the official J-Quants service information when aligning them with
+  # the subscription in use.
+  # How many days behind today the newest row of the configured plan is.
   delay_days: 84
-  # How far back from that newest row the plan keeps data. Two years on
-  # the Free plan.
+  # How far back from that newest row the configured plan keeps data.
   retention_days: 730
 
 charts:

--- a/doc/DATA_CONTRACT.md
+++ b/doc/DATA_CONTRACT.md
@@ -46,8 +46,8 @@ party obtains them.
 
 ## 2. How the consumer parses each file
 
-Two parsing styles are in use on the other side, and the difference decides what
-is safe to change.
+The consumer handles the generated files in the distinct ways listed below, and
+the difference decides what is safe to change.
 
 | Style | Files | Safe to reorder? | Safe to rename? |
 |---|---|---|---|
@@ -195,7 +195,7 @@ lookup silently, leaving an empty cell rather than an error.
 
 ## 6. The summary files
 
-All four share one shape and differ only in which columns they carry.
+The summary files share one row shape and differ only in which columns they carry.
 
 - Tab separated, **not** comma separated.
 - One header line beginning `Code`. The dashboard skips it by that literal.
@@ -343,10 +343,10 @@ dividend yield, market capitalisation — scraped from a Yahoo Japan quote page
 that no longer exists.
 
 Nothing replaces it. Restoring it would mean choosing a new source for
-fundamentals; the J-Quants Free plan does not carry them in this form, and no
-other source that is free, licensed for this use and offered for machine access
-has been adopted. Scraping one is not an option here. The link has been removed
-from the dashboard so that nothing dangles, and neither repository refers to the
+fundamentals; no free source licensed for this use and offered for machine
+access has been adopted. Scraping one is not an option here. The link has been
+removed from the dashboard so that nothing dangles, and neither repository
+refers to the
 file.
 
 The four market indices the pipeline used to chart are withdrawn on the same

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -26,8 +26,8 @@ It never writes into `data/` or `clf/`, and it never writes a key into `env`.
 Deploying cannot disturb generated data, updating data never needs a code
 change, and rotating the credential never needs either.
 
-Six things are kept apart on purpose, and it is worth naming them because they
-used to be one directory of copied files:
+These concerns are kept apart on purpose, and it is worth naming them because
+they used to be one directory of copied files:
 
 | Concern | Where |
 |---|---|
@@ -47,9 +47,9 @@ The dashboard's group reaches exactly one of those.
 ## Before you begin
 
 - Linux with cron, `sudo`, and Python **3.11 or later**.
-- **A J-Quants API key.** Register at the J-Quants site, subscribe to the Free
-  plan, and issue a key from the dashboard. The pipeline cannot fetch without
-  one, and there is no other way to give it prices.
+- **A J-Quants API key.** Obtain a key for the J-Quants subscription used by
+  this deployment. The pipeline cannot fetch without one, and there is no
+  other way to give it prices.
 - A Japanese TrueType font for the chart captions:
   `sudo apt-get install fonts-vlgothic`.
 - A local mail relay on port 25 if reports are to be sent.
@@ -146,7 +146,7 @@ generated directory and nothing else.
 ## Configure
 
 Configuration is optional. Without any, the pipeline writes into the data
-directory `run.sh` exports, fetches the whole window the Free plan keeps, and
+directory `run.sh` exports, fetches the whole configured plan window, and
 sends no mail.
 
 The settings worth knowing about are under `jquants`, which describe the plan
@@ -154,16 +154,18 @@ rather than the program:
 
 | Key | Default | What it is |
 |---|---|---|
-| `delay_days` | 84 | How far behind today the plan's newest row is. Twelve weeks on the Free plan; 0 on a paid one |
+| `delay_days` | 84 | How far behind today the configured plan's newest row is |
 | `retention_days` | 730 | How far back from that point the plan keeps data |
 | `request_interval` | 1.0 | Minimum seconds between two requests |
 | `timeout` | 30 | Seconds one request may take |
 | `max_retries` | 3 | Attempts for a throttled or failed request |
 
-`delay_days` and `retention_days` are stated in this one place and nowhere else
-in the system. If the plan's terms change, this is what changes. Everything
-downstream — the dates a fetch asks for, whether stored data counts as current,
-whether a summary treats a stock as stale — follows from them.
+The runtime defaults are defined in `finance/config.py`; this table exposes
+them to the operator as configuration defaults. They are not assertions about
+current provider terms. Consult the official J-Quants service information when
+aligning them with the subscription in use. Everything downstream — the dates
+a fetch asks for, whether stored data counts as current, whether a summary
+treats a stock as stale — follows from the configured values.
 
 `pipeline.start_date` is empty by default, which means the whole window the plan
 keeps. A date older than that is raised to it, and the run says so in the log.
@@ -231,15 +233,14 @@ The header must begin `Date,Open,High,Low,Close,Volume,Adj Close`, and the last
 two fields of the last row must be the classification and the prediction rather
 than empty.
 
-`data_source.txt` must name the source and carry a `last_trading_day`. **It will
-not be today.** On the Free plan it is about twelve weeks back, and that is
-correct rather than a fault; it is the figure the dashboard shows so that nobody
-reads these pages as live market data. If it is empty, the run analysed nothing.
+`data_source.txt` must name the source and carry a `last_trading_day`. It may
+be earlier than today by the configured publication delay, and that is correct
+rather than a fault; it is the figure the dashboard shows so that nobody reads
+these pages as live market data. If it is empty, the run analysed nothing.
 
 If the command fails with a message about `JQUANTS_API_KEY`, the environment
 file is empty or was not sourced. If it fails with an authentication error, the
-key is wrong or the subscription has lapsed — the Free plan is cancelled
-automatically after a year and can be registered again.
+key is wrong or the subscription does not currently permit the request.
 
 Then run the whole job once:
 
@@ -262,11 +263,11 @@ on stderr, which is what cron will mail.
 
 18:10 on weekdays, after the Tokyo close. `deploy.sh` installs it.
 
-The hour no longer matters as much as it did. The Free plan publishes weeks in
-arrears, so a run at 18:10 collects what was published long before it, and an
-occasional missed evening costs nothing that the next run does not pick up. The
-schedule is kept because it works and the operator relies on it, not because the
-data requires it.
+The schedule is kept for operational consistency. The configured publication
+window, not the wall-clock hour, determines which dates a fetch may request.
+An occasional missed evening is recovered by the next updating run, which asks
+for data newer than the last stored row. The operator relies on the schedule;
+the data source does not require this particular hour.
 
 It is cron rather than a systemd timer because a plain daily batch has no
 ordering, activation or resource requirement that a timer would serve. Changing
@@ -373,8 +374,7 @@ transient fetch failure resolves itself the next evening.
 empty or unreadable. `run.sh` checks before it starts, so nothing was fetched.
 
 **Every stock fails to authenticate** — the key is wrong, was revoked, or the
-subscription lapsed. The Free plan is cancelled automatically after a year;
-re-registering and issuing a new key is the fix.
+subscription lapsed. Re-registering and issuing a new key is the fix.
 
 **Every stock fails with a rate limit** — the job is asking too quickly.
 Raise `jquants.request_interval`.

--- a/doc/REQUIREMENTS.md
+++ b/doc/REQUIREMENTS.md
@@ -103,18 +103,18 @@ A provider that fails any of the three is not adopted, and a shortfall in the
 data is never made up from one that does. In particular, no page written for a
 human is scraped, and no undocumented endpoint is called.
 
-The plan's limits are requirements, not defects:
+The configured subscription limits are requirements, not defects:
 
-- **A publication delay.** The newest available row is weeks behind today. The
-  system fetches no further forward than the plan publishes, and states the last
-  trading day it holds so that the delay is visible to the reader.
-- **A bounded history.** The plan keeps a fixed span behind that point. A
-  request for anything older is raised to the oldest date kept, and every
-  analysis must be computable inside the span.
+- **A publication window.** The system respects the configured `delay_days`,
+  fetches no further forward than that window permits, and states the last
+  trading day it holds so that the data age is visible to the reader.
+- **A bounded history.** The system respects the configured `retention_days`.
+  A request for anything older is raised to the oldest date in that window, and
+  every analysis must be computable inside the configured span.
 - **A rate limit.** Requests are paced and a refusal is retried rather than
   worked around.
 
-The interfaces the Free plan does not carry are not obtained elsewhere. Market
+Interfaces not adopted by this pipeline are not obtained elsewhere. Market
 index values are the case that matters here; see section 7.4.
 
 ### 7.3 Stored history
@@ -130,8 +130,8 @@ operator performs rather than something a nightly job decides.
 ### 7.4 Market indices
 
 None. The system previously charted four market indices fetched from a provider
-it no longer uses. The J-Quants Free plan carries no index values, and
-no free, licensed, machine-readable source for them has been adopted.
+it no longer uses. No index dataset has been adopted for the current pipeline,
+and no free, licensed, machine-readable alternative source has been adopted.
 
 The requirement is therefore withdrawn rather than met by other means. The
 analysis of Japanese shares stands without a reference index: no indicator,

--- a/finance/config.py
+++ b/finance/config.py
@@ -61,8 +61,8 @@
 #  - FINANCE_JQUANTS_BASE_URL: Base URL of the API. Defaults to the
 #      published v2 endpoint.
 #  - FINANCE_JQUANTS_TIMEOUT: Seconds one HTTP request may take.
-#  - FINANCE_JQUANTS_MAX_RETRIES: Retries of a throttled or failed
-#      request.
+#  - FINANCE_JQUANTS_MAX_RETRIES: Maximum attempts for a throttled or
+#      failed request.
 #  - FINANCE_JQUANTS_REQUEST_INTERVAL: Minimum seconds between two
 #      requests.
 #  - FINANCE_JQUANTS_DELAY_DAYS: How many days behind today the newest
@@ -122,10 +122,10 @@ DEFAULT_TIMEOUT = 30.0
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_REQUEST_INTERVAL = 1.0
 
-# The Free plan publishes data up to twelve weeks behind today, and
-# keeps two years of it behind that point. Both are defaults rather than
-# constants: a plan change moves them, and a paid subscription sets
-# delay_days to 0. Nothing else in the package spells either number.
+# Runtime defaults for the configured publication and retention window.
+# They are settings rather than fixed service facts because provider terms
+# can change. Current plan terms belong to the official J-Quants
+# documentation; these values are only the defaults this program uses.
 DEFAULT_DELAY_DAYS = 84
 DEFAULT_RETENTION_DAYS = 730
 


### PR DESCRIPTION
## Summary

- remove remaining count-based documentation inconsistencies
- repair the stale README section link
- separate program defaults from service-owned plan facts
- align max_retries wording with the implementation's attempt semantics

## Validation

- `git diff --check`
- static assertions for every targeted wording replacement
- `python3 -m py_compile finance/config.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_013GLHzPf9DKeS5LspxvW5eB)_