### PR TITLE
docs: eliminate remaining documentation drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,12 @@ sends no mail.
 | `FINANCE_MAIL_HOSTNAME_SUFFIX` | `mail.hostname_suffix` | - | Only send from a host whose name ends with this |
 
 `delay_days` and `retention_days` describe the subscription assumptions used
-by the program. Their runtime defaults are defined in `finance/config.py` and
-exposed in this Configuration table; current user-facing documentation does
-not duplicate those numeric defaults elsewhere. Current provider terms
-belong to the official J-Quants documentation. They are settings because a
-plan's published terms can change, and because a paid subscription sets
-`delay_days` to `0`. Everything downstream follows from them:
+by the program. Their runtime defaults are defined in `finance/config.py`.
+The Configuration table, `config.yml.sample`, and `doc/DEPLOYMENT.md` expose
+those defaults for operators; they document this program's configuration
+rather than current provider terms. Current provider terms belong to the
+official J-Quants documentation. These values are settings because a plan's
+published terms can change. Everything downstream follows from them:
 which dates a fetch asks for, whether stored data counts as current, and whether
 a summary treats a stock as stale.
 
@@ -318,16 +318,15 @@ and records the provenance; steps 9 and 10 draw from what it already stored. The
 job therefore makes one pass over the network per stock per day, and only step 1
 needs the API key.
 
-That pass is often empty, and that is correct. The plan publishes weeks in
-arrears, so once the stored history reaches the newest published date there is
-nothing to add until the window moves. The run says so by name and rewrites
-nothing.
+That pass is often empty, and that is correct. Once the stored history reaches
+the newest date allowed by the configured publication window, there is nothing
+to add until that window moves. The run says so by name and rewrites nothing.
 
 A step that fails is reported and the job carries on to the next, because a
 broken summary is no reason to skip the charts. The exit status is non-zero if
 any step failed, so cron mails the operator rather than the failure passing
 unnoticed. Within step 1 the same rule applies per stock: one delisted code does
-not cost the other thirty their charts.
+not cost the remaining stocks their charts.
 
 The schedule lives in `cron.d/stock` and is unchanged:
 

--- a/doc/BASIC_DESIGN.md
+++ b/doc/BASIC_DESIGN.md
@@ -57,7 +57,8 @@ module opens a file or imports an I/O module, and that no library module prints.
 
 The package version and the one place logging is configured. Imports nothing
 beyond the standard library, so every other module can import it freely. The
-three commands append to the same log file, so the format is decided once.
+command-line entry points append to the same log file, so the format is
+decided once.
 
 ### 4.2 `finance/config.py`
 
@@ -115,7 +116,7 @@ refreshed on the recent window only.
 ### 4.8 `finance/aggregation.py`
 
 `Aggregator` reduces many indicator frames to one summary table. It holds the
-two positional column layouts as constants, the ten day staleness rule, and the
+positional column layouts as constants, the ten day staleness rule, and the
 historical ratio formula. It is handed frames; it reads nothing.
 
 ### 4.9 `finance/charts.py`
@@ -222,7 +223,7 @@ call, and the data source layer is deliberately kept ignorant of it.
 
 ### 4.15 `finance/cli/`
 
-Four entry points and their shared helpers. Each parses arguments, resolves
+The command-line entry points and their shared helpers. Each parses arguments, resolves
 settings, calls one function in the application layer and reports what happened.
 No analysis is written here.
 
@@ -286,8 +287,9 @@ never sees a mutable object it could change.
 properties — how far behind today its newest row is, and how far back it keeps
 data. `fetch_window(today)` turns those into the range a fetch may ask for, and
 raises a configured start date that predates the plan rather than refusing it.
-Both numbers live here and nowhere else, because they are properties of a
-subscription that can change.
+Their runtime defaults are defined in `finance/config.py`. The README,
+`config.yml.sample`, and `doc/DEPLOYMENT.md` expose the same values to
+operators, while current provider terms remain the provider's responsibility.
 
 The API key is read from `JQUANTS_API_KEY` and from nothing else. It is refused
 if it appears in the configuration file, and its field is excluded from the
@@ -333,7 +335,7 @@ something that failed.
 
 ## 10. Testing
 
-Four groups, described in the README. Two structural rules matter to this
+The test groups are described in the README. Two structural rules matter to this
 design:
 
 - No test in the default run reaches the network. The price source is a protocol
@@ -342,5 +344,5 @@ design:
   enforced rather than merely documented.
 
 The committed fixtures `test/stock_N225.csv` and `test/ti_N225.csv` predate the
-rewrite and are load bearing: the contract test regenerates all 42 computed
-columns of the second from the first.
+rewrite and are load bearing: the contract test regenerates the computed
+columns defined by the data contract from the first fixture.

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -121,9 +121,9 @@ sudo chmod 600 /var/stock/env
 ```
 
 `run.sh` sources it and refuses to start if the key is empty, so a missing
-credential is a message at 18:10 rather than thirty failed fetches.
+credential is a message at 18:10 rather than a failed fetch for every stock.
 
-Four things not to do with it:
+Do not do any of the following with it:
 
 - **Do not put it in `config.yml`.** The settings loader refuses a key found
   there. A file in the working tree is one careless `git add` from being
@@ -219,7 +219,7 @@ FINANCE_DATA_DIR=/var/stock/data FINANCE_MODEL_DIR=/var/stock/clf \
     /var/stock/.venv/bin/finance-charts -c 7203 -n トヨタ -y 240 -u
 ```
 
-Then check the five things that matter:
+Then check the generated files and provenance:
 
 ```bash
 ls -l /var/stock/data/stock_7203.csv /var/stock/data/ti_7203.csv \
@@ -386,9 +386,9 @@ integration checks, which are the only tests that touch it:
 cd /path/to/finance && JQUANTS_API_KEY=... .venv/bin/pytest -m integration
 ```
 
-**A fetch succeeds but returns nothing new, every evening** — expected. The plan
-publishes in arrears; once the stored history reaches the newest published date,
-there is nothing to add until the window moves. The log says so by name.
+**A fetch succeeds but returns nothing new, every evening** — expected. The
+configured publication window can leave no newer date available once the
+stored history reaches the newest permitted date. The log says so by name.
 
 **Charts appear, summaries are empty** — the summaries drop any stock whose
 newest indicator row is more than ten days older than the newest date the plan
@@ -397,10 +397,10 @@ summaries, which is what `run.sh` does in that order anyway. If `jquants.
 delay_days` is wrong for the subscription, this is the symptom: the reference
 date moves and everything looks stale.
 
-**The dashboard says the data is twelve weeks old** — it is, and it is meant to
-say so. That is the Free plan's publication delay, not a stalled pipeline.
-Compare `last_trading_day` in `/var/stock/data/data_source.txt` with what the
-plan currently publishes.
+**The dashboard says the data is older than expected** — the dashboard reports
+the `last_trading_day` recorded by the pipeline. Compare that date with what the
+configured subscription currently publishes and with `jquants.delay_days`.
+Do not infer a provider plan delay from a hard-coded duration in this document.
 
 **Captions render as boxes** — the caption font is missing. Install one and set
 `charts.font_path`.

--- a/doc/POLICY.md
+++ b/doc/POLICY.md
@@ -493,8 +493,9 @@ copyright holder; the decision came from the copyright holder.
   block, between `Source Code` and `Contact`.
 - `pyproject.toml` carries the matching
   `license = { text = "GPL-3.0-or-later OR LGPL-3.0-or-later" }`.
-- The README, `LICENSE.md` and the module headers state one thing. A change to
-  the license is a change to all four places in the same commit.
+- The README, `LICENSE.md`, `pyproject.toml`, and the module headers must state
+  the same licence. A licence change updates each of those locations in the same
+  commit.
 - Do not vendor third-party code into this repository. Dependencies are declared
   in `pyproject.toml` and installed from PyPI, which keeps their licenses theirs
   and this file short.

--- a/doc/REQUIREMENTS.md
+++ b/doc/REQUIREMENTS.md
@@ -29,7 +29,7 @@ schedule, without anybody present.
 
 **It is software for one person's private analysis of their own investments.**
 That is a design premise rather than a description of current usage, and the
-following four statements are binding on every change:
+following statements are binding on every change:
 
 - The market data it obtains is not redistributed to anyone.
 - No continuing analysis service built on that data is provided to anyone.
@@ -89,7 +89,7 @@ and optionally a longer name for a chart caption.
 Daily open, high, low, close, volume and adjusted close, for each code in the
 list, from the **J-Quants API Free plan**.
 
-The provider is chosen on three conditions, in this order:
+The provider is chosen under the following conditions, in this order:
 
 1. **Free to an individual**, so that the system's premise of personal,
    no-cost operation holds without a subscription.
@@ -191,7 +191,7 @@ volume ratios.
 
 ## 11. The models
 
-Two, per stock, both trained on the return index:
+The per-stock models are trained on the return index:
 
 - A classifier answering whether the next value rises.
 - A ridge regression estimating the next value, reported as a price.
@@ -206,9 +206,11 @@ and nothing else.
 
 ## 12. Charts
 
-Three per stock, distinguished by window length and by file name prefix. Each
+Per stock, the system produces standard, short, and long chart views,
+distinguished by window length and by file name prefix. Each
 carries a candlestick price panel with trend overlays and, optionally, an
-oscillator panel below it. Two switches control how much is drawn.
+oscillator panel below it. The `-a`/`--axis` switch selects the panel layout, and the `-p`/`--complexity`
+switch selects how many series each panel carries.
 
 The images are for a person to look at. Their content is specified; their pixels
 are not, and no requirement here asks for reproducible rendering.
@@ -269,7 +271,7 @@ a setting.
 
 ## 18. Secrets
 
-One: the J-Quants API key.
+The pipeline credential is the J-Quants API key.
 
 - It is supplied through the environment, and through nothing else. It gets no
   command line option, because a command line is readable by every user of the


### PR DESCRIPTION
## Summary

- align documentation with the existing configuration source-of-truth model
- remove copied provider-plan assumptions and derived current counts
- replace maintenance-sensitive count and ordinal wording with named concepts

## Validation

- `git diff --check`
- verified that only the specified documentation files changed
- verified that implementation, configuration defaults, tests, and `doc/VERSIONS` are unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_013GLHzPf9DKeS5LspxvW5eB)_