### PR TITLE
Align provider-owned terms and design wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ boxes.
 
 ## 5. The API Key
 
-Register at the J-Quants site, subscribe to the Free plan, and issue a key from
-its dashboard. Then export it:
+Obtain an API key by following the current instructions in the
+[official J-Quants service information](https://jpx-jquants.com/). Then export it:
 
 ```bash
 export JQUANTS_API_KEY=your-key-here

--- a/doc/BASIC_DESIGN.md
+++ b/doc/BASIC_DESIGN.md
@@ -305,7 +305,7 @@ Each layer converts what it catches:
 
 | Layer | Catches | Raises |
 |---|---|---|
-| `datasources/jquants` | any HTTP client exception, any refused status | `DataSourceError` and its four subtypes |
+| `datasources/jquants` | any HTTP client exception, any refused status | the `DataSourceError` hierarchy |
 | `indicators` | any TA-Lib exception | `IndicatorError` |
 | `models` | any scikit-learn exception | `ModelError` |
 | `storage` | `OSError`, parser errors | `StorageError`, `DataFormatError` |
@@ -320,8 +320,8 @@ Above them:
   defect and its traceback is wanted.
 - A list run with any failure exits 1, so cron reports a partial run.
 
-Two writes are deliberately conservative. An empty frame is never written over
-an existing file, and stored price rows are never recalculated.
+Writes are deliberately conservative. An empty frame is never written over an
+existing file, and stored price rows are never recalculated.
 
 ## 9. Logging
 
@@ -335,8 +335,8 @@ something that failed.
 
 ## 10. Testing
 
-The test groups are described in the README. Two structural rules matter to this
-design:
+The test groups are described in the README. The structural rules that matter to
+this design are:
 
 - No test in the default run reaches the network. The price source is a protocol
   and tests inject a stub.

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -374,7 +374,10 @@ transient fetch failure resolves itself the next evening.
 empty or unreadable. `run.sh` checks before it starts, so nothing was fetched.
 
 **Every stock fails to authenticate** — the key is wrong, was revoked, or the
-subscription lapsed. Re-registering and issuing a new key is the fix.
+configured subscription does not currently permit the request. Check the key
+and subscription status against the
+[official J-Quants service information](https://jpx-jquants.com/), then update
+`JQUANTS_API_KEY` if the credential must be replaced.
 
 **Every stock fails with a rate limit** — the job is asking too quickly.
 Raise `jquants.request_interval`.


### PR DESCRIPTION
## Purpose

Finish the documentation consistency cleanup without changing runtime behavior.

## Changes

- Point API-key acquisition at the provider's current official instructions instead of copying the current subscription procedure.
- Stop prescribing a provider-owned re-registration procedure for authentication failures.
- Remove redundant aggregate counts from the basic design where the listed structure already carries the information.

## Validation

- `git diff --check`: PASS
- stale provider-procedure wording check: PASS
- redundant aggregate wording check: PASS
- changed-file scope check: PASS

---
_Generated by [Claude Code](https://claude.ai/code/session_013GLHzPf9DKeS5LspxvW5eB)_