### PR TITLE
docs: remove provider-owned key issuance wording

### DIFF
--- a/finance/config.py
+++ b/finance/config.py
@@ -40,8 +40,8 @@
 #  Contact: idnanashi@gmail.com
 #
 #  Environment Variables:
-#  - JQUANTS_API_KEY: The J-Quants API key, issued from the J-Quants
-#      dashboard. Required for any run that fetches. Read from the
+#  - JQUANTS_API_KEY: The J-Quants API key. Required for any run that
+#      fetches. Read from the
 #      environment only, never from the configuration file. The name
 #      matches the one the official J-Quants client reads, so a host
 #      that already exports it needs nothing added.


### PR DESCRIPTION
## Summary
- Remove the remaining provider-owned API-key issuance wording from the config module documentation.

## Validation
- `git diff --check`
- verified that only `finance/config.py` changed

## Scope
- Comment-only change.
- No runtime behavior, version, dependency, or release-history change.

---
_Generated by [Claude Code](https://claude.ai/code/session_011TG1FkFoHPF66rJpJdE67a)_