### PR TITLE
Fix finance runtime contract and validation inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ that is not a number, mail enabled without addresses — is refused before any
 work begins. This job runs unattended, and a setting rejected at 18:10 is
 cheaper than a wrong file written at 18:11.
 
+A present setting that cannot be interpreted is rejected before work starts.
+Boolean settings accept only `1/0`, `true/false`, `yes/no` and `on/off`
+(case-insensitive); the mail port must be in `1..65535`, and a log level must
+be a standard Python logging level name.
+
 The chart caption is Japanese and needs a font that can render it. On Debian and
 Ubuntu:
 
@@ -373,10 +378,12 @@ finance-charts -c 7203 -n トヨタ -y 60
 | `-a, --axis N` | `1` price panel only, `2` adds the oscillator panel |
 | `-p, --complexity N` | `1` to `3`, how many series each panel carries |
 
-Without `-u` the run draws a chart from stored data and writes nothing else — no
-fetch, no CSV, no model, and **no API key needed**. The window given to `-y`
-also selects the chart file: over 300 rows writes `long_`, 60 or fewer writes
-`short_`, anything between writes `chart_`.
+Without `-u` the run draws a chart from stored data and writes nothing else —
+no fetch, no CSV, no model, and no API key needed. A single-stock run reads
+`stock_CODE.csv` by default, or the file named by `-r`; if that stored file is
+missing, the stock fails rather than turning the chart-only run into a fetch.
+The window given to `-y` also selects the chart file: over 300 rows writes
+`long_`, 60 or fewer writes `short_`, anything between writes `chart_`.
 
 A stock code is four characters as it appears in a stock list. The five
 character form the API uses exists only inside the data source layer. A code
@@ -439,7 +446,7 @@ two years.
 ### Shared options
 
 `--config PATH`, `--data-dir PATH` and `--log-level NAME` are accepted by all
-three.
+four commands.
 
 ### Compatibility
 
@@ -629,8 +636,10 @@ rule against committing market data would get broken.
 ```
 
 The script installs the package into a virtual environment under `/var/stock`,
-puts `run.sh` and the cron entry in place, and creates the directories the job
-writes to. It never writes into `data/` or `clf/`.
+puts `run.sh` and the cron entry in place, creates the directories the job uses,
+and seeds `stocks.txt` and `topix_core30.txt` only when they are missing. It
+does not overwrite generated data or model contents, although deployment does
+reapply their ownership and permissions.
 
 | Concern | Location |
 |---|---|

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,10 +14,10 @@
 #  position on disk.
 #
 #  Code and data are separated in what this script touches. It replaces
-#  the virtual environment and the batch script, and it creates data/,
-#  data/history/ and clf/ if they are absent, but it never writes into
-#  them. Updating the pipeline cannot disturb generated data, and
-#  generated data cannot require a code change.
+#  the virtual environment and the batch script, creates data/,
+#  data/history/ and clf/ when absent, seeds the shipped stock lists only
+#  when missing, and reapplies ownership and permissions. It does not
+#  overwrite generated data or model contents.
 #
 #  The credential is separated from both. This script creates an empty
 #  environment file readable only by root, for the operator to write

--- a/doc/BASIC_DESIGN.md
+++ b/doc/BASIC_DESIGN.md
@@ -69,6 +69,11 @@ line, environment, YAML file, default.
 **The only module in the package that reads the environment.** A value that is
 present but unusable is refused here, before any work begins.
 
+Known YAML sections must be mappings, Boolean values use an explicit accepted
+vocabulary, mail ports are bounded to the TCP port range, and log levels are
+validated before logging starts. The same log-level rule is applied to the
+command-line override before it replaces the loaded setting.
+
 ### 4.3 `finance/errors.py`
 
 The error hierarchy. Its purpose is that a caller can distinguish a source that
@@ -191,6 +196,14 @@ above it, by `Settings.fetch_window`.
 The per stock pipeline: load prices, compute indicators, apply both models,
 write both CSVs, draw the chart. It owns the order and the paths.
 
+A chart-only request resolves its stored price path first and reads it without
+touching the source; a missing stored file is that stock's failure, not a reason
+to fetch. Only an updating request enters the fetch path.
+
+The adapter may carry all-empty rows introduced by business-day reindexing.
+Those rows are useful while normalizing a calendar but are removed from the
+price persistence candidate; a partially empty trading row is retained.
+
 `run_many()` runs a list, catching each stock's failure so that the rest
 continue, and returning both the results and the failures.
 
@@ -234,6 +247,17 @@ is run once by hand and is not in `run.sh`.
 ## 5. The flow of one stock
 
 ```text
+finance-charts -c 7203 -y 60
+    |
+    | read stock_7203.csv                    storage
+    | missing -> fail, no fetch              analysis
+    v
+    | reindex to business days, drop gaps    analysis
+    | compute indicators/models              domain
+    | write chart only                       charts
+```
+
+```text
 finance-charts -s stocks.txt -y 240 -u
     |
     | read_stock_list()                       stocklist
@@ -243,6 +267,7 @@ for each entry:
     | read stock_CODE.csv                     storage
     | fetch from the next business day        datasources/jquants
     | combine, stored rows winning            analysis
+    | drop all-empty calendar gaps            analysis
     | write stock_CODE.csv                    storage
     v
     | reindex to business days, drop gaps,

--- a/doc/DATA_CONTRACT.md
+++ b/doc/DATA_CONTRACT.md
@@ -91,9 +91,11 @@ incrementally.
 
 - Comma separated, index label `Date`, dates as `YYYY-MM-DD`.
 - Columns, in this order: `Open`, `High`, `Low`, `Close`, `Volume`, `Adj Close`.
-- One row per trading day. Rows are never removed and, once written, never
-  recalculated: an update fetches only dates after the last stored row and
-  combines them with the stored rows winning any overlap.
+- One row per trading day. An all-empty row introduced only by business-day
+  calendar normalization is not a stored row. Stored trading-day rows are never
+  removed and, once written, never recalculated: an update fetches only dates
+  after the last stored row and combines them with the stored rows winning any
+  overlap.
 - Every column is on **one basis**: the share-split adjusted series. `Adj Close`
   and `Close` are both the adjusted close, and `Open`, `High`, `Low` and
   `Volume` are the adjusted open, high, low and volume. Indicators are computed
@@ -216,7 +218,13 @@ predict, name`.
 
 ### 6.2 The nine column layout
 
-`topix_core30.csv` (`rsi9`) and `screening_rsi14.csv` (`rsi14`):
+`topix_core30.csv` (`rsi9`):
+
+```text
+Code	Open	High	Low	Close	Change	Ratio	rsi9	Name
+```
+
+`screening_rsi14.csv` (`rsi14`):
 
 ```text
 Code	Open	High	Low	Close	Change	Ratio	rsi14	Name
@@ -281,7 +289,7 @@ source from the view and the code and never looks inside the file.
 | File | Window | Written by |
 |---|---|---|
 | `chart_CODE.png` | 61 to 300 rows | the 240-row run |
-| `long_CODE.png` | over 300 rows | the 600-row run |
+| `long_CODE.png` | over 300 rows | the 480-row run |
 | `short_CODE.png` | 60 rows or fewer | the 60-row run |
 
 The prefix is chosen by the window length, not by an option:

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -16,15 +16,19 @@ rather than as `bin/` and `lib/` copied into place.
 - `/var/stock/run.sh` — the batch script
 - `/etc/cron.d/stock` — the schedule
 
-It creates, if absent, and otherwise leaves alone:
+It creates these directories when they are absent:
 
 - `/var/stock/data`, `/var/stock/data/history`, `/var/stock/clf`
-- `/var/stock/data/stocks.txt` and `topix_core30.txt`, only when missing
+
+It seeds these files only when they are missing:
+
+- `/var/stock/data/stocks.txt`
+- `/var/stock/data/topix_core30.txt`
 - `/var/stock/env`, empty, mode 600, root only — the file the API key goes in
 
-It never writes into `data/` or `clf/`, and it never writes a key into `env`.
-Deploying cannot disturb generated data, updating data never needs a code
-change, and rotating the credential never needs either.
+On every deployment it reapplies ownership and permissions under the deployment
+root. It does not overwrite generated data or model contents, existing stock
+lists, or the contents of an existing `env`; it never writes an API key.
 
 These concerns are kept apart on purpose, and it is worth naming them because
 they used to be one directory of copied files:

--- a/doc/REQUIREMENTS.md
+++ b/doc/REQUIREMENTS.md
@@ -238,6 +238,8 @@ The job runs unattended, so how it fails is part of what it is.
 - **Errors are distinguishable.** A source that could not be reached, a stored
   file that is malformed, an indicator that could not be computed and a file
   that could not be written are different problems and are reported as such.
+- **A chart-only run never becomes a fetching run.** If its stored price file is
+  absent, that stock fails; only a run explicitly given `--update` may fetch.
 
 ## 15. Networking
 

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -1,6 +1,14 @@
 finance Repository Version History
 ==================================
 
+v1.0.2 (Release Date: TBD)
+--------------------------
+- Keep chart-only runs on stored prices, leaving fetches exclusive to
+  `--update`.
+- Keep `stock_CODE.csv` to trading-day rows by omitting empty calendar gaps.
+- Reject malformed configuration values instead of silently defaulting them.
+- Reject malformed J-Quants data rows instead of silently discarding them.
+
 v1.0.1 (2026-08-26)
 -------------------
 - Replace Yahoo Finance with the J-Quants API v2 Free plan as the price source, so

--- a/finance/__init__.py
+++ b/finance/__init__.py
@@ -32,7 +32,7 @@
 
 import logging
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"

--- a/finance/analysis.py
+++ b/finance/analysis.py
@@ -41,6 +41,8 @@
 #  - NumPy, pandas
 #
 #  Version History:
+#  v1.1 2026-09-09
+#       Keep chart-only runs on stored prices and persist trading-day rows only.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -206,6 +208,10 @@ class Analysis:
         """
         Return the price history and whether this run may write.
 
+        A chart-only request never fetches: it resolves the stored price
+        path and reads it, and a missing file is that stock's failure
+        rather than a reason to reach the source.
+
         A run asked to update reads what is stored, fetches from the
         business day after the last stored row, and combines the two
         with the stored rows winning. That is what keeps a historical
@@ -217,31 +223,38 @@ class Analysis:
         saying so is what keeps the job from making one pointless
         request per stock per day for the whole of the plan's delay.
         """
+        filename = request.csvfile or storage.price_filename(request.code)
+        path = Path(filename)
+        if not path.is_absolute():
+            path = self.settings.data_file(filename)
+
+        if not request.update:
+            stored = storage.read_price_csv(path)
+            logger.info("Read %d stored rows for %s", len(stored), request.code)
+            return stored, False
+
         start, end = self.settings.fetch_window(self.today)
 
-        if request.csvfile is None:
-            prices = self._fetch(request.code, start, end)
-            storage.write_price_csv(
-                prices, self.settings.data_file(storage.price_filename(request.code))
-            )
-            return prices, request.update
-
-        path = Path(request.csvfile)
-        if not path.is_absolute():
-            path = self.settings.data_file(request.csvfile)
-
         if not path.is_file():
-            logger.info("No stored prices for %s; fetching the full window", request.code)
-            prices = self._fetch(request.code, start, end)
+            fresh = self._trading_rows(self._fetch(request.code, start, end))
+            if fresh.empty:
+                return fresh, False
             storage.write_price_csv(
-                prices, self.settings.data_file(storage.price_filename(request.code))
+                fresh, self.settings.data_file(storage.price_filename(request.code))
             )
-            return prices, request.update
+            return fresh, True
 
         stored = storage.read_price_csv(path)
         logger.info("Read %d stored rows for %s", len(stored), request.code)
-        if not request.update or stored.empty:
-            return stored, False
+
+        if stored.empty:
+            fresh = self._trading_rows(self._fetch(request.code, start, end))
+            if fresh.empty:
+                return fresh, False
+            storage.write_price_csv(
+                fresh, self.settings.data_file(storage.price_filename(request.code))
+            )
+            return fresh, True
 
         next_day = self._next_business_day(stored.index[-1])
         if next_day > end:
@@ -252,15 +265,15 @@ class Analysis:
             )
             return stored, False
 
-        fetched = self._fetch(request.code, next_day, end)
-        fresh = fetched.dropna(how="all")
+        fresh = self._trading_rows(self._fetch(request.code, next_day, end))
         logger.info("Fetched %d new rows for %s", len(fresh), request.code)
         if fresh.empty:
             # Nothing new: leave the indicator file and the models as
             # they are, so a holiday does not restamp the dashboard.
             return stored, False
 
-        combined = stored.combine_first(fetched)
+        combined = stored.combine_first(fresh)
+        combined = self._trading_rows(combined)
         storage.write_price_csv(
             combined, self.settings.data_file(storage.price_filename(request.code))
         )
@@ -275,6 +288,11 @@ class Analysis:
         """ Return the business day after the given date. """
         following = pd.date_range(start=timestamp, periods=2, freq="B")
         return following[1].date()
+
+    @staticmethod
+    def _trading_rows(frame: pd.DataFrame) -> pd.DataFrame:
+        """ Return rows carrying at least one price value. """
+        return frame.dropna(how="all")
 
     def _classify(self, code: str, ret_index: pd.Series, remember: bool) -> int:
         """ Train the classifier and return its verdict on the next day. """

--- a/finance/cli/__init__.py
+++ b/finance/cli/__init__.py
@@ -5,7 +5,7 @@
 # finance/cli/__init__.py: Shared command line helpers
 #
 #  Description:
-#  Hold what the three commands have in common: the exit codes they
+#  Hold what the four commands have in common: the exit codes they
 #  agree on, the options every one of them accepts, and the wrapper that
 #  turns an expected failure into a message on standard error and a
 #  status, rather than a traceback.
@@ -30,6 +30,8 @@
 #  - Standard library only
 #
 #  Version History:
+#  v1.1 2026-09-09
+#       Validate command-line log levels with the shared configuration rule.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -45,7 +47,7 @@ from dataclasses import replace
 from pathlib import Path
 
 from finance import __version__, configure_logging
-from finance.config import Settings, load_settings
+from finance.config import Settings, load_settings, validate_log_level
 from finance.errors import ConfigurationError, FinanceError
 
 EXIT_SUCCESS = 0
@@ -89,7 +91,7 @@ def resolve_settings(arguments: argparse.Namespace) -> Settings:
         if settings.history_dir == settings.data_dir / "history":
             overrides["history_dir"] = data_dir / "history"
     if getattr(arguments, "log_level", None):
-        overrides["log_level"] = arguments.log_level
+        overrides["log_level"] = validate_log_level(arguments.log_level)
     if not overrides:
         return settings
     return replace(settings, **overrides)

--- a/finance/config.py
+++ b/finance/config.py
@@ -86,6 +86,8 @@
 #  - PyYAML
 #
 #  Version History:
+#  v1.1 2026-09-09
+#       Reject malformed sections, booleans, log levels and mail ports at load.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -288,8 +290,14 @@ def _load_file(path: Path) -> dict[str, Any]:
 
 def _section(config: dict[str, Any], name: str) -> dict[str, Any]:
     """ Return a mapping section of the configuration. """
-    section = config.get(name)
-    return section if isinstance(section, dict) else {}
+    if name not in config:
+        return {}
+    section = config[name]
+    if not isinstance(section, dict):
+        raise ConfigurationError(
+            "Configuration section {0} must be a mapping".format(name)
+        )
+    return section
 
 
 def _first(*values: Any) -> Any:
@@ -300,11 +308,16 @@ def _first(*values: Any) -> Any:
     return None
 
 
-def _as_bool(value: Any) -> bool:
-    """ Interpret a configuration value as a boolean. """
+def _as_bool(value: Any, name: str) -> bool:
+    """ Interpret a configuration value as a boolean, or refuse it. """
     if isinstance(value, bool):
         return value
-    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+    candidate = str(value).strip().lower()
+    if candidate in {"1", "true", "yes", "on"}:
+        return True
+    if candidate in {"0", "false", "no", "off"}:
+        return False
+    raise ConfigurationError("{0} must be a boolean, got {1!r}".format(name, value))
 
 
 def _as_int(value: Any, name: str) -> int:
@@ -353,6 +366,31 @@ def _as_non_negative_int(value: Any, name: str) -> int:
     if number < 0:
         raise ConfigurationError("{0} must not be negative, got {1}".format(name, number))
     return number
+
+
+def _as_port(value: Any, name: str) -> int:
+    """ Interpret a configuration value as a TCP port, or refuse it. """
+    number = _as_int(value, name)
+    if not 1 <= number <= 65535:
+        raise ConfigurationError(
+            "{0} must be between 1 and 65535, got {1}".format(name, number)
+        )
+    return number
+
+
+def validate_log_level(value: Any) -> str:
+    """
+    Return a logging level name, or refuse an unknown one.
+
+    Shared with finance.cli so that the command-line --log-level override
+    is held to the same rule as an environment or configuration-file value.
+    """
+    candidate = str(value)
+    if candidate.upper() not in logging.getLevelNamesMapping():
+        raise ConfigurationError(
+            "log level must be a standard logging level name, got {0!r}".format(value)
+        )
+    return candidate
 
 
 def _parse_date(value: str, name: str) -> date:
@@ -416,7 +454,9 @@ def load_settings(config_file: str | os.PathLike[str] | None = None) -> Settings
         ),
         start_date=start_date,
         font_path=str(_first(_env("FONT_PATH"), charts.get("font_path"), DEFAULT_FONT_PATH)),
-        log_level=str(_first(_env("LOG_LEVEL"), logging_section.get("level"), "INFO")),
+        log_level=validate_log_level(
+            _first(_env("LOG_LEVEL"), logging_section.get("level"), "INFO")
+        ),
         mail=_load_mail(mail_section),
         jquants=_load_jquants(jquants_section),
     )
@@ -477,7 +517,10 @@ def _load_jquants(section: dict[str, Any]) -> JQuantsSettings:
 
 def _load_mail(section: dict[str, Any]) -> MailSettings:
     """ Resolve the notification settings and refuse an unusable combination. """
-    enabled = _as_bool(_first(_env("MAIL_ENABLED"), section.get("enabled"), False))
+    enabled = _as_bool(
+        _first(_env("MAIL_ENABLED"), section.get("enabled"), False),
+        "mail enabled",
+    )
     sender = str(_first(_env("MAIL_FROM"), section.get("sender"), "") or "")
     recipient = str(_first(_env("MAIL_TO"), section.get("recipient"), "") or "")
     if enabled and not (sender and recipient):
@@ -487,7 +530,7 @@ def _load_mail(section: dict[str, Any]) -> MailSettings:
     return MailSettings(
         enabled=enabled,
         host=str(_first(_env("MAIL_HOST"), section.get("host"), "localhost")),
-        port=_as_int(_first(_env("MAIL_PORT"), section.get("port"), 25), "mail port"),
+        port=_as_port(_first(_env("MAIL_PORT"), section.get("port"), 25), "mail port"),
         sender=sender,
         recipient=recipient,
         hostname_suffix=str(

--- a/finance/datasources/jquants.py
+++ b/finance/datasources/jquants.py
@@ -51,6 +51,9 @@
 #  from the unadjusted ones, because substituting a different basis
 #  silently is the failure this module exists to prevent.
 #
+#  A non-object item in the response data list is likewise refused rather than
+#  silently discarded.
+#
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
@@ -61,6 +64,8 @@
 #  - pandas, requests
 #
 #  Version History:
+#  v1.1 2026-09-09
+#       Refuse non-object response rows instead of silently discarding them.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -451,7 +456,13 @@ class JQuantsSource:
                 raise DataSourceError(
                     "The {0} member of the response for {1} is not a list".format(DATA_KEY, code)
                 )
-            rows.extend(item for item in batch if isinstance(item, dict))
+            for row_number, item in enumerate(batch, start=1):
+                if not isinstance(item, dict):
+                    raise DataSourceError(
+                        "The data member of response page {0} for {1} has a non-object row at "
+                        "position {2}".format(page, code, row_number)
+                    )
+                rows.append(item)
 
             key = body.get(PAGINATION_KEY)
             if not key:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "finance"
-version = "1.0.1"
+version = "1.0.2"
 description = "Personal batch pipeline producing technical analysis data and charts for finance-dashboard"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -24,6 +24,10 @@
 #  - The window length selects the chart prefix.
 #  - A failing stock is reported and the rest of the list continues.
 #  - An empty price history is refused.
+#  - Chart-only uses the default stored price file and never fetches.
+#  - A chart-only run without stored prices fails without fetching.
+#  - An update without stored history fetches the full window.
+#  - Persisted prices omit all-empty calendar gaps.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/finance
@@ -35,6 +39,8 @@
 #  - pandas, pytest
 #
 #  Version History:
+#  v1.1 2026-09-09
+#       Cover chart-only stored-file isolation and update fetch boundaries.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -48,7 +54,7 @@ import pandas as pd
 import pytest
 
 from finance.analysis import Analysis, AnalysisRequest, run_many
-from finance.errors import DataFormatError, DataSourceError
+from finance.errors import DataFormatError, DataSourceError, StorageError
 
 CODE = "N225"
 RUN_DATE = date(2015, 3, 23)
@@ -123,6 +129,23 @@ def test_without_update_nothing_is_written(settings, stub_source, stored):
     assert source.calls == []
 
 
+def test_chart_only_uses_the_default_price_file_without_fetch(settings, stub_source, stored):
+    analysis, source = make_analysis(settings, stub_source)
+    result = analysis.run(AnalysisRequest(code=CODE, days=180, update=False))
+
+    assert source.calls == []
+    assert result.chart_path.is_file()
+    assert result.wrote_indicators is False
+
+
+def test_chart_only_without_stored_prices_fails_without_fetch(settings, stub_source):
+    analysis, source = make_analysis(settings, stub_source)
+    with pytest.raises(StorageError, match="does not exist"):
+        analysis.run(AnalysisRequest(code=CODE, days=180, update=False, csvfile=None))
+
+    assert source.calls == []
+
+
 def test_with_update_both_files_and_both_models_are_written(
     settings, stub_source, stored, raw_prices
 ):
@@ -141,6 +164,7 @@ def test_with_update_both_files_and_both_models_are_written(
     assert (settings.model_dir / "clf_N225.pickle").is_file()
     assert (settings.model_dir / "reg_N225.pickle").is_file()
     assert source.calls, "an updating run must fetch"
+    assert source.calls == [(CODE, date(2015, 3, 23), RUN_DATE)]
 
 
 def test_no_new_prices_leaves_the_indicator_file_alone(settings, stub_source, stored):
@@ -184,11 +208,11 @@ def test_the_model_outputs_land_on_the_last_row(settings, stub_source, stored):
     assert result.predicted > 0
 
 
-def test_a_missing_stored_file_falls_back_to_fetching(settings, stub_source, raw_prices):
+def test_update_without_stored_prices_fetches_the_full_window(
+    settings, stub_source, raw_prices
+):
     analysis, source = make_analysis(settings, stub_source, raw_prices)
-    result = analysis.run(
-        AnalysisRequest(code=CODE, days=180, csvfile="stock_N225.csv", update=True)
-    )
+    result = analysis.run(AnalysisRequest(code=CODE, days=180, update=True))
 
     # The whole history is requested from the configured start date, so
     # the run covers whatever the source has rather than the window.
@@ -200,7 +224,7 @@ def test_a_missing_stored_file_falls_back_to_fetching(settings, stub_source, raw
 def test_an_empty_history_is_refused(settings, stub_source):
     analysis, _ = make_analysis(settings, stub_source)
     with pytest.raises(DataFormatError, match="No price data"):
-        analysis.run(AnalysisRequest(code="9999", days=180))
+        analysis.run(AnalysisRequest(code="9999", days=180, update=True))
 
 
 def test_one_failing_stock_does_not_end_a_list_run(settings, stub_source, stored):
@@ -214,7 +238,7 @@ def test_one_failing_stock_does_not_end_a_list_run(settings, stub_source, stored
 
     analysis = Analysis(settings, FailingSource(), today=RUN_DATE)
     requests = [
-        AnalysisRequest(code="BROKEN", days=180),
+        AnalysisRequest(code="BROKEN", days=180, update=True),
         AnalysisRequest(code=CODE, days=180, csvfile=stored.name),
     ]
 
@@ -232,7 +256,11 @@ def test_a_run_of_only_failures_reports_them_all(settings):
 
     analysis = Analysis(settings, FailingSource(), today=RUN_DATE)
     results, failures = run_many(
-        analysis, [AnalysisRequest(code="1111"), AnalysisRequest(code="2222")]
+        analysis,
+        [
+            AnalysisRequest(code="1111", update=True),
+            AnalysisRequest(code="2222", update=True),
+        ],
     )
 
     assert results == []

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -5,7 +5,7 @@
 # test_cli.py: The command line entry points
 #
 #  Description:
-#  Assert that the three commands accept the options the batch scripts
+#  Assert that the four commands accept the options the batch scripts
 #  pass them, that they write where they are told, and that they return
 #  the exit status the operator's cron mail depends on.
 #
@@ -29,6 +29,10 @@
 #  - A run that would fetch without an API key fails before it does.
 #  - A failing stock makes the whole run exit 1.
 #  - The notify command declines quietly when mail is unconfigured.
+#  - A single-stock chart-only run uses the default stored file, with no
+#    API key needed.
+#  - A chart-only list run continues past a stock with no stored file.
+#  - An unknown command-line log level fails as a configuration error.
 #
 #  Author: id774 (More info: http://id774.net)
 #  Source Code: https://github.com/id774/finance
@@ -40,6 +44,8 @@
 #  - pandas, pytest
 #
 #  Version History:
+#  v1.1 2026-09-09
+#       Cover all four commands and chart-only and log-level failure paths.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -52,6 +58,7 @@ import pytest
 
 from finance.cli import EXIT_FAILURE, EXIT_SUCCESS, EXIT_USAGE
 from finance.cli import charts as charts_cli
+from finance.cli import migrate as migrate_cli
 from finance.cli import notify as notify_cli
 from finance.cli import summary as summary_cli
 
@@ -142,7 +149,9 @@ def test_notify_defaults_match_the_ruby_script():
 
 
 @pytest.mark.parametrize(
-    "module", [charts_cli, summary_cli, notify_cli], ids=["charts", "summary", "notify"]
+    "module",
+    [charts_cli, summary_cli, notify_cli, migrate_cli],
+    ids=["charts", "summary", "notify", "migrate"],
 )
 @pytest.mark.parametrize("flag", ["--help", "--version"])
 def test_help_and_version_exit_zero(module, flag):
@@ -152,7 +161,9 @@ def test_help_and_version_exit_zero(module, flag):
 
 
 @pytest.mark.parametrize(
-    "module", [charts_cli, summary_cli, notify_cli], ids=["charts", "summary", "notify"]
+    "module",
+    [charts_cli, summary_cli, notify_cli, migrate_cli],
+    ids=["charts", "summary", "notify", "migrate"],
 )
 def test_an_unknown_option_exits_two(module):
     with pytest.raises(SystemExit) as raised:
@@ -356,6 +367,63 @@ def test_charts_writes_where_data_dir_points(tmp_path, monkeypatch, raw_prices):
     assert (data_dir / "chart_7203.png").is_file()
     # Without -u nothing else is written.
     assert not (data_dir / "ti_7203.csv").exists()
+
+
+def test_single_stock_chart_only_uses_default_stored_data_without_an_api_key(
+    tmp_path, monkeypatch, raw_prices
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("JQUANTS_API_KEY", raising=False)
+    data_dir = tmp_path / "out"
+    data_dir.mkdir()
+    raw_prices.to_csv(data_dir / "stock_7203.csv", index_label="Date")
+
+    status = charts_cli.main(
+        ["-c", "7203", "-n", "トヨタ", "-y", "180", "--data-dir", str(data_dir)]
+    )
+
+    assert status == EXIT_SUCCESS
+    assert (data_dir / "chart_7203.png").is_file()
+    assert not (data_dir / "ti_7203.csv").exists()
+    assert not (data_dir / "data_source.txt").exists()
+
+
+def test_chart_only_missing_stock_continues_without_fetching(
+    tmp_path, monkeypatch, raw_prices, capsys
+):
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "out"
+    data_dir.mkdir()
+    (data_dir / "stocks.txt").write_text("1111,欠損\n7203,トヨタ\n", encoding="utf-8")
+    raw_prices.to_csv(data_dir / "stock_7203.csv", index_label="Date")
+
+    class ExplodingSource:
+        def __init__(self, settings):
+            self.settings = settings
+
+        def fetch(self, code, start, end):
+            raise AssertionError("chart-only fetched")
+
+    monkeypatch.setattr(charts_cli, "LazySource", ExplodingSource)
+    status = charts_cli.main(["-s", "stocks.txt", "-y", "180", "--data-dir", str(data_dir)])
+
+    assert status == EXIT_FAILURE
+    stderr = capsys.readouterr().err
+    assert "1111" in stderr
+    assert "does not exist" in stderr
+    assert (data_dir / "chart_7203.png").is_file()
+
+
+def test_an_unknown_command_line_log_level_fails_as_configuration(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    status = charts_cli.main(
+        ["-c", "7203", "--log-level", "VERBOSEST", "--data-dir", str(tmp_path)]
+    )
+
+    assert status == EXIT_FAILURE
+    stderr = capsys.readouterr().err
+    assert "[ERROR] Configuration:" in stderr
+    assert "log level" in stderr
 
 
 def test_a_failing_stock_makes_the_run_exit_one(tmp_path, monkeypatch, capsys):

--- a/test/test_contract.py
+++ b/test/test_contract.py
@@ -32,7 +32,7 @@
 #  - ti_CODE.csv keeps its name, separator, index label, column order
 #    and header spelling, and normalizes to the keys the dashboard reads.
 #  - classified and predicted appear on the last row only.
-#  - stock_CODE.csv keeps its six columns in canonical order.
+#  - stock_CODE.csv keeps canonical columns and stores trading-day rows only.
 #  - The ten and nine column summary layouts parse positionally into the
 #    dashboard's own column lists.
 #  - stocks.txt parses as code and name.
@@ -52,6 +52,8 @@
 #  - pandas, pytest
 #
 #  Version History:
+#  v1.2 2026-09-09
+#       Verify that stored price history omits empty calendar gaps.
 #  v1.1 2026-08-24
 #       Keep provenance text independent from data age and verify the
 #       generation and trading dates as separate facts.
@@ -73,6 +75,7 @@ import pytest
 
 from finance import storage
 from finance.aggregation import Aggregator
+from finance.analysis import Analysis, AnalysisRequest
 from finance.charts import chart_filename, chart_prefix
 from finance.datasources import CANONICAL_COLUMNS
 from finance.indicators import build_indicator_frame
@@ -304,6 +307,40 @@ def test_committed_fixture_uses_the_canonical_order():
         (Path(__file__).parent / "stock_N225.csv").read_text(encoding="utf-8").splitlines()[0]
     )
     assert header == "Date," + ",".join(PRICE_COLUMNS)
+
+
+def test_price_file_omits_empty_calendar_gaps_but_keeps_partial_rows(settings):
+    index = pd.DatetimeIndex(["2024-01-04", "2024-01-05", "2024-01-08"])
+    frame = pd.DataFrame(
+        {
+            "Open": [100.0, float("nan"), 103.0],
+            "High": [101.0, float("nan"), 104.0],
+            "Low": [99.0, float("nan"), 102.0],
+            "Close": [100.5, float("nan"), 103.5],
+            "Volume": [1000.0, float("nan"), float("nan")],
+            "Adj Close": [100.5, float("nan"), 103.5],
+        },
+        index=index,
+    )
+
+    class Source:
+        """ Answers every fetch with the invented frame above. """
+
+        def fetch(self, code, start, end):
+            return frame.copy()
+
+    # _load_prices is called directly, bypassing run(), to isolate the
+    # price persistence contract from indicators, models and charts.
+    analysis = Analysis(settings, Source(), today=date(2024, 1, 9))
+    analysis._load_prices(AnalysisRequest(code="7203", update=True))
+
+    written = storage.read_price_csv(settings.data_file("stock_7203.csv"))
+    written_dates = set(written.index.strftime("%Y-%m-%d"))
+
+    assert "2024-01-04" in written_dates
+    assert "2024-01-05" not in written_dates
+    assert "2024-01-08" in written_dates
+    assert pd.isna(written.loc["2024-01-08", "Volume"])
 
 
 # --------------------------------------------------------------------

--- a/test/test_datasources.py
+++ b/test/test_datasources.py
@@ -32,6 +32,7 @@
 #  - A repeated pagination key is refused rather than looped on.
 #  - The API key travels in the x-api-key header and in nothing else.
 #  - A missing API key fails before a request is made.
+#  - A non-object item in data is refused rather than silently discarded.
 #  - 401 and 403 raise AuthenticationError.
 #  - 429 raises RateLimitError once the retries are spent.
 #  - 400 and 404 raise DataUnavailableError.
@@ -52,6 +53,8 @@
 #  - pandas, pytest
 #
 #  Version History:
+#  v1.1 2026-09-09
+#       Cover rejection of non-object rows in the response data list.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -325,6 +328,13 @@ def test_a_response_without_a_data_member_is_refused():
     session = FakeSession([FakeResponse(body={"rows": []})])
     with pytest.raises(DataSourceError, match="data"):
         source(session).fetch("7203", START, END)
+
+
+def test_a_non_object_data_row_is_refused():
+    session = FakeSession([FakeResponse(body={"data": [row("2024-01-04", 100.0), "not-a-row"]})])
+    with pytest.raises(DataSourceError, match=r"page 1.*position 2"):
+        source(session).fetch("7203", START, END)
+    assert len(session.calls) == 1
 
 
 @pytest.mark.parametrize("status", [401, 403])

--- a/test/test_storage_and_config.py
+++ b/test/test_storage_and_config.py
@@ -21,7 +21,7 @@
 #  - A missing or malformed file is reported as the right error.
 #  - Models round trip, and a corrupt one reads as absent.
 #  - Defaults, environment, file and precedence between them.
-#  - A malformed date, port or configuration file is refused.
+#  - Malformed dates, booleans, sections, log levels and mail ports are refused.
 #  - The mail host guard.
 #
 #  Author: id774 (More info: http://id774.net)
@@ -34,6 +34,8 @@
 #  - pandas, pytest
 #
 #  Version History:
+#  v1.1 2026-09-09
+#       Cover strict parsing of known configuration values and sections.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -277,6 +279,66 @@ def test_a_malformed_port_is_refused(tmp_path, monkeypatch):
     monkeypatch.setenv("FINANCE_MAIL_PORT", "not-a-port")
     with pytest.raises(ConfigurationError, match="integer"):
         load_settings()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("1", True),
+        ("true", True),
+        ("yes", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("off", False),
+        ("TRUE", True),
+    ],
+)
+def test_boolean_spellings_are_explicit(tmp_path, monkeypatch, value, expected):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FINANCE_MAIL_ENABLED", value)
+    if expected:
+        monkeypatch.setenv("FINANCE_MAIL_FROM", "sender@example.test")
+        monkeypatch.setenv("FINANCE_MAIL_TO", "recipient@example.test")
+    assert load_settings().mail.enabled is expected
+
+
+def test_an_unknown_boolean_is_refused(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FINANCE_MAIL_ENABLED", "treu")
+    with pytest.raises(ConfigurationError, match="boolean"):
+        load_settings()
+
+
+@pytest.mark.parametrize("section", ["paths", "pipeline", "charts", "logging", "mail", "jquants"])
+def test_a_known_section_must_be_a_mapping(tmp_path, monkeypatch, section):
+    monkeypatch.chdir(tmp_path)
+    config = tmp_path / "config.yml"
+    config.write_text("{0}: []\n".format(section), encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="{0}.*mapping".format(section)):
+        load_settings(config)
+
+
+def test_an_unknown_log_level_is_refused(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FINANCE_LOG_LEVEL", "VERBOSEST")
+    with pytest.raises(ConfigurationError, match="log level"):
+        load_settings()
+
+
+@pytest.mark.parametrize("port", ["0", "-1", "65536"])
+def test_a_mail_port_outside_the_tcp_range_is_refused(tmp_path, monkeypatch, port):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FINANCE_MAIL_PORT", port)
+    with pytest.raises(ConfigurationError, match="1 and 65535"):
+        load_settings()
+
+
+def test_the_highest_tcp_port_is_accepted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FINANCE_MAIL_PORT", "65535")
+    assert load_settings().mail.port == 65535
 
 
 def test_mail_without_addresses_is_refused(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Keep chart-only runs on stored prices and make missing stored data fail
  without fetching.
- Persist only trading-day price rows, dropping all-empty calendar gaps.
- Reject malformed configuration values before work starts.
- Reject non-object J-Quants data rows instead of silently discarding them.
- Align the related CLI, data-contract and deployment documentation.

## Compatibility

- CLI option names and valid option semantics are unchanged.
- Valid configuration values and precedence are unchanged.
- Generated file names, separators, columns and column order are unchanged.
- Indicator, model and summary formulas are unchanged.
- The corrected behaviours were accidental fallback/acceptance paths, not
  supported compatibility paths.

## Version

- Candidate repository version: v1.0.2
- Release Date: TBD

## Validation

- `pytest` — PASS (490 passed, 2 deselected)
- `ruff check .` — PASS
- `sh -n run.sh` — PASS
- `sh -n deploy.sh` — PASS

## Scope

No dependency, cron, formula, provider endpoint, or finance-dashboard change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGJm1r7JvjV9P8PCuuCTEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGJm1r7JvjV9P8PCuuCTEr)_