### PR TITLE
Update id774.net header URL to HTTPS

### DIFF
--- a/bin/charts.py
+++ b/bin/charts.py
@@ -15,7 +15,7 @@
 #  script; this file exists only so that an un-updated caller does not
 #  break, and it can be deleted once none remain.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/bin/summary.py
+++ b/bin/summary.py
@@ -12,7 +12,7 @@
 #  It holds no logic. Every option is parsed by the command it forwards
 #  to.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,7 +26,7 @@
 #  the shell history of every host it ran on. An existing file is left
 #  exactly as it is.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/__init__.py
+++ b/finance/__init__.py
@@ -15,7 +15,7 @@
 #  same log file. One format, decided once, is what keeps their output
 #  readable when interleaved.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/aggregation.py
+++ b/finance/aggregation.py
@@ -20,7 +20,7 @@
 #  This module computes; it does not read or write. It is handed the
 #  frames it aggregates.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/analysis.py
+++ b/finance/analysis.py
@@ -31,7 +31,7 @@
 #  not told what plan it is on, and this layer does not know how the
 #  window was arrived at.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/charts.py
+++ b/finance/charts.py
@@ -29,7 +29,7 @@
 #  the axis the old chart had, where consecutive business days sit
 #  side by side and a weekend leaves no gap.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/cli/__init__.py
+++ b/finance/cli/__init__.py
@@ -15,7 +15,7 @@
 #  happened. No analysis is written here, and none is duplicated between
 #  a command and the batch scripts that drive it.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/cli/charts.py
+++ b/finance/cli/charts.py
@@ -13,7 +13,7 @@
 #  crontab pass them. optparse was replaced by argparse; nothing else
 #  about the interface moved.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/cli/migrate.py
+++ b/finance/cli/migrate.py
@@ -14,7 +14,7 @@
 #  the operator's stored history has no business happening at 18:10
 #  without them.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/cli/notify.py
+++ b/finance/cli/notify.py
@@ -14,7 +14,7 @@
 #  running the pipeline for a look at a chart should not fail its run
 #  over a mail it was never meant to send.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/cli/summary.py
+++ b/finance/cli/summary.py
@@ -13,7 +13,7 @@
 #  and each combination produces one of the files finance-dashboard
 #  reads, so the letters and their meanings are fixed.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/config.py
+++ b/finance/config.py
@@ -34,7 +34,7 @@
 #  property of the plan that can change, and the pipeline needs exactly
 #  one place to change it in.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/datasources/__init__.py
+++ b/finance/datasources/__init__.py
@@ -21,7 +21,7 @@
 #  worse answer than the configuration error an unknown name already
 #  gets.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/datasources/jquants.py
+++ b/finance/datasources/jquants.py
@@ -54,7 +54,7 @@
 #  A non-object item in the response data list is likewise refused rather than
 #  silently discarded.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/errors.py
+++ b/finance/errors.py
@@ -22,7 +22,7 @@
 #  needs its input corrected. Collapsing them into one type would leave
 #  the nightly log unable to distinguish these conditions.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/features.py
+++ b/finance/features.py
@@ -22,7 +22,7 @@
 #  lookup on a DatetimeIndex. Both are now explicit .iloc calls. The
 #  arithmetic is unchanged and reproduces the original labels exactly.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/indicators.py
+++ b/finance/indicators.py
@@ -21,7 +21,7 @@
 #  from TA-Lib 0.4 to 0.7 and from pandas 0.16 to 3.x is an API change
 #  only, verified column by column against test/ti_N225.csv.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/migration.py
+++ b/finance/migration.py
@@ -29,7 +29,7 @@
 #  them free to look at what was there. Removing that directory is
 #  another decision, and also theirs.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/models.py
+++ b/finance/models.py
@@ -19,7 +19,7 @@
 #  loading and saving belong to finance/storage.py, so that these
 #  classes can be exercised without a filesystem.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/notification.py
+++ b/finance/notification.py
@@ -20,7 +20,7 @@
 #  test asserts the message that would be sent by supplying its own
 #  transport, and never opens a connection.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/reporting.py
+++ b/finance/reporting.py
@@ -14,7 +14,7 @@
 #  what was reported at the time, which is also why the ratio formula in
 #  finance.aggregation is preserved rather than corrected.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/stocklist.py
+++ b/finance/stocklist.py
@@ -22,7 +22,7 @@
 #  indices: a code in a stock list is a listing, and the data source
 #  refuses anything that cannot be one.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/finance/storage.py
+++ b/finance/storage.py
@@ -18,7 +18,7 @@
 #  layers above it own the layout and a test can point it at a temporary
 #  directory.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,7 @@
 #  status is non-zero if any step failed, so cron mails the operator
 #  instead of the failure passing unnoticed.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,7 +18,7 @@
 #  fetched from the current provider joins it, here or anywhere else in
 #  the suite.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/integration/test_jquants_live.py
+++ b/test/integration/test_jquants_live.py
@@ -34,7 +34,7 @@
 #  - A rejected key raises AuthenticationError rather than something
 #    from the HTTP client.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_aggregation.py
+++ b/test/test_aggregation.py
@@ -27,7 +27,7 @@
 #  - The legacy expectation that a directory with no matching files
 #    aggregates to an empty result.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -29,7 +29,7 @@
 #  - An update without stored history fetches the full window.
 #  - Persisted prices omit all-empty calendar gaps.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_charts.py
+++ b/test/test_charts.py
@@ -28,7 +28,7 @@
 #  - An empty frame is refused.
 #  - A missing indicator column is skipped rather than fatal.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -34,7 +34,7 @@
 #  - A chart-only list run continues past a stock with no stored file.
 #  - An unknown command-line log level fails as a configuration error.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_contract.py
+++ b/test/test_contract.py
@@ -42,7 +42,7 @@
 #  - History files carry the dated double extension.
 #  - Chart file names follow the window length rule.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_datasources.py
+++ b/test/test_datasources.py
@@ -43,7 +43,7 @@
 #  - An unknown source name is refused.
 #  - No error message and no log record carries the API key.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_features_and_models.py
+++ b/test/test_features_and_models.py
@@ -27,7 +27,7 @@
 #    AttributeError, which is what the legacy code did.
 #  - An unknown estimator name is refused.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_indicators.py
+++ b/test/test_indicators.py
@@ -26,7 +26,7 @@
 #  - A bad window parameter surfaces as IndicatorError, not as a TA-Lib
 #    exception.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_migration.py
+++ b/test/test_migration.py
@@ -25,7 +25,7 @@
 #  - The daily batch script does not call the migration.
 #  - No module under datasources refers to the migration.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_notification.py
+++ b/test/test_notification.py
@@ -19,7 +19,7 @@
 #  - A transport failure becomes NotificationError.
 #  - A missing report is reported before any transport is used.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -34,7 +34,7 @@
 #  - No module outside config.py reads the API key, and none logs it.
 #  - Console scripts resolve.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_plan_window.py
+++ b/test/test_plan_window.py
@@ -29,7 +29,7 @@
 #  - Staleness is measured against the newest published date.
 #  - The lookback the longest indicator needs fits inside the window.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com

--- a/test/test_storage_and_config.py
+++ b/test/test_storage_and_config.py
@@ -24,7 +24,7 @@
 #  - Malformed dates, booleans, sections, log levels and mail ports are refused.
 #  - The mail host guard.
 #
-#  Author: id774 (More info: http://id774.net)
+#  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
 #  Contact: idnanashi@gmail.com


### PR DESCRIPTION
## Summary

- Mechanically changed `More info: http://id774.net` to `More info: https://id774.net` in file headers (40 files).
- No changes other than the URL scheme (`http` → `https`).
- No version changes.
- No changes to Version History, README, or other documentation.
- No test additions or changes (test files only had their own header line updated).

## Mandatory Validation (actual results)

- Old notation remaining: 0 — PASS
- Diffs other than URL scheme: 0 — PASS
- Out-of-scope changes: 0 — PASS
- Version changes: 0 — PASS
- Version History changes: 0 — PASS
- Other documentation changes: 0 — PASS
- Test changes: 0 — PASS
- Dependency changes: 0 — PASS
- `git diff --check`: PASS (0 whitespace errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)