### PR TITLE
Fix finance validation and write safety inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,15 +236,17 @@ Copy the sample to start:
 cp config.yml.sample config.yml
 ```
 
-A value that is present but unusable — a date that is not `YYYY-MM-DD`, a port
-that is not a number, mail enabled without addresses — is refused before any
-work begins. This job runs unattended, and a setting rejected at 18:10 is
-cheaper than a wrong file written at 18:11.
+An explicit configuration file named by `--config` or `FINANCE_CONFIG` must
+exist and contain valid YAML. The implicit `./config.yml` may be absent, in
+which case defaults are used. Any present but unusable setting is rejected
+before work starts.
 
-A present setting that cannot be interpreted is rejected before work starts.
 Boolean settings accept only `1/0`, `true/false`, `yes/no` and `on/off`
 (case-insensitive); the mail port must be in `1..65535`, and a log level must
-be a standard Python logging level name.
+be a standard Python logging level name. J-Quants timeout values must be finite
+and positive, request intervals must be finite and non-negative, and
+`retention_days` must be at least 281 days so the current required analysis
+lookback fits inside the configured window.
 
 The chart caption is Japanese and needs a font that can render it. On Debian and
 Ubuntu:
@@ -339,12 +341,12 @@ The schedule lives in `cron.d/stock` and is unchanged:
 10 18  * * 1-5 root test -x /var/stock/run.sh && /var/stock/run.sh
 ```
 
-18:10 on weekdays, after the Tokyo close. The hour matters less than it did: the
-Free plan publishes weeks in arrears, so a run collects what was published long
-before it, and a missed evening costs nothing the next run does not pick up. It
-is cron rather than a systemd timer because a plain daily batch has no ordering,
-activation or resource requirement that a timer would serve, and because it
-works.
+18:10 on weekdays, after the Tokyo close. The wall-clock hour does not decide
+data freshness: the configured publication window decides the newest date a
+fetch may request, and a missed evening is recovered by the next updating run.
+It is cron rather than a systemd timer because a plain daily batch has no
+ordering, activation or resource requirement that a timer would serve, and
+because it works.
 
 `my_stocks.txt`, the operator's holdings, is not in this repository. It lives in
 the data directory on the host and uses the same format as `stocks.txt`. The
@@ -374,7 +376,7 @@ finance-charts -c 7203 -n トヨタ -y 60
 | `-r, --readfile FILE` | Read stored prices from this CSV instead of `stock_CODE.csv` |
 | `-u, --update` | Fetch, rewrite both CSVs and persist the retrained models |
 | `-d, --date DATE` | Earliest date to fetch. A date before the plan's window is raised to it |
-| `-y, --days N` | Trailing rows to analyse and chart. `0` means all |
+| `-y, --days N` | Trailing rows to analyse and chart. `0` means all; negative values are rejected |
 | `-a, --axis N` | `1` price panel only, `2` adds the oscillator panel |
 | `-p, --complexity N` | `1` to `3`, how many series each panel carries |
 
@@ -403,7 +405,7 @@ finance-summary -o screening_rsi14.csv -r 1 -c rsi14 -a -k rsi14
 |---|---|
 | `-s, --stock FILE` | Stock list to aggregate. Defaults to the configured list |
 | `-o, --output FILE` | Output name inside the data directory |
-| `-r, --range N` | Rows the change spans. `1` compares the last two |
+| `-r, --range N` | Rows the change spans. Must be at least `1`; `1` compares the last two |
 | `-k, --sortkey KEY` | Column to sort by. Defaults to `Ratio` |
 | `-a, --ascending` | Sort ascending |
 | `-c, --screening_key KEY` | Report this indicator instead of the model outputs |
@@ -494,9 +496,9 @@ Two details are load bearing and easy to lose:
   [section 11 of the data contract](doc/DATA_CONTRACT.md).
 
 `data_source.txt` is why the dashboard can say how old its figures are. It
-carries the last trading day the data covers, which is weeks behind the
-generation date, and an unknown value is left **empty** rather than filled in
-with today.
+carries the last trading day the data covers. That date may precede the
+generation date by the configured publication delay, and an unknown value is
+left **empty** rather than filled in with today.
 
 `ref_index.csv` was linked by earlier versions of the dashboard and was never
 produced here. The link is gone; see
@@ -593,7 +595,7 @@ are kept because deleting them would delete the evidence that the arithmetic has
 not moved across three library generations. They are not refreshed, and nothing
 from the current provider joins them.
 
-The suite is in four groups:
+The suite is in five groups:
 
 - **Regression** — every indicator, feature and model value asserted against the
   numbers the previous test suite asserted, on the same committed fixture. These
@@ -645,7 +647,7 @@ reapply their ownership and permissions.
 |---|---|
 | Code | `/var/stock/.venv` |
 | API key | `/var/stock/env`, mode 600, root only |
-| Commands | `/var/stock/.venv/bin/finance-charts`, `-summary`, `-notify` |
+| Commands | `/var/stock/.venv/bin/finance-charts`, `/var/stock/.venv/bin/finance-summary`, `/var/stock/.venv/bin/finance-notify`, `/var/stock/.venv/bin/finance-migrate` |
 | Batch script | `/var/stock/run.sh` |
 | Data | `/var/stock/data` |
 | History | `/var/stock/data/history` |
@@ -655,8 +657,10 @@ reapply their ownership and permissions.
 
 `TARGET_DIR`, `PYTHON` and `DATA_GROUP` override the defaults. Code, data and
 the credential are separated in responsibility: a deployment replaces the
-virtual environment and the batch script, touches neither `data/` nor `clf/`,
-and never writes a key into `env`. Updating data needs no code change, and
+virtual environment and the batch script. It does not overwrite generated data,
+model contents or existing stock-list contents; it may create missing
+directories or shipped stock lists and reapplies ownership and permissions.
+It never writes a key into `env`. Updating data needs no code change, and
 rotating the credential needs neither.
 
 The dashboard's group reaches `data/` and nothing else — not the virtual
@@ -715,12 +719,14 @@ This is the change that needs action on both sides.
    provider's series and this one's do not mean the same thing, and the daily
    job merges stored rows with fetched ones, so the older files are archived and
    rebuilt rather than merged. Nothing is deleted.
-3. **Expect a shorter history.** The Free plan keeps about two years, where the
-   old configuration fetched from 2014. Every indicator fits inside the window,
-   and a test asserts it.
-4. **Expect delayed data.** The newest row is weeks old, and
-   `data_source.txt` says by how much. This is the plan working as intended, not
-   a stalled pipeline.
+3. **Expect history to be bounded by the configured retention window.** An
+   explicit start date older than that window is raised to its lower bound.
+   The configured window must still be large enough for every analysis; values
+   below the current 281-day minimum are rejected at configuration load.
+4. **Expect data age to follow the configured publication window.**
+   `data_source.txt` records the actual last trading day. A delayed row is
+   expected when the configured window says so; do not infer a fixed number of
+   weeks from this document.
 5. **Drop the market indices from your stock lists.** They cannot be fetched on
    this plan and are refused as codes. The shipped
    `stocks.txt` now holds listed equities.

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -48,6 +48,8 @@ jquants:
   # How many days behind today the newest row of the configured plan is.
   delay_days: 84
   # How far back from that newest row the configured plan keeps data.
+  # Must be at least 281 days so the current required analysis lookback
+  # fits inside the configured window.
   retention_days: 730
 
 charts:

--- a/doc/BASIC_DESIGN.md
+++ b/doc/BASIC_DESIGN.md
@@ -74,6 +74,14 @@ vocabulary, mail ports are bounded to the TCP port range, and log levels are
 validated before logging starts. The same log-level rule is applied to the
 command-line override before it replaces the loaded setting.
 
+An explicit configuration source -- `--config`, or failing that a non-blank
+`FINANCE_CONFIG` -- must name a file that exists and parses as valid YAML; the
+implicit `./config.yml` may be absent, which is read as an empty
+configuration. J-Quants timeout and request-interval values must be finite,
+and `retention_days` must be at least `MIN_RETENTION_DAYS`, the shortest window
+that still fits the longest indicator lookback this repository currently
+requires.
+
 ### 4.3 `finance/errors.py`
 
 The error hierarchy. Its purpose is that a caller can distinguish a source that
@@ -88,6 +96,10 @@ continue or stop on that difference.
 
 Parses the comma separated stock lists into `StockEntry` values. Every entry
 names a listing on the Tokyo exchange; market indices are not accepted.
+
+Blank lines are ignored. Every non-blank record must carry a non-empty code and
+short name; a missing required value is a `DataFormatError`, not a silently
+skipped entry.
 
 ### 4.5 `finance/indicators.py`
 
@@ -152,6 +164,11 @@ reported as absent rather than raised, because estimators pickled by an older
 scikit-learn do not load on a newer one and refusing to run for that reason
 would stop the whole job the first time the library is upgraded.
 
+Generated CSV and provenance text writes are replacement-safe: content is
+completed in a sibling temporary file and atomically replaces the target only
+after the write succeeds. A failed write leaves the last good target intact.
+Existing target ownership and mode are preserved across replacement.
+
 ### 4.11 `finance/datasources/`
 
 `__init__.py` declares the `StockDataSource` protocol — one method, `fetch(code,
@@ -178,6 +195,10 @@ Failures are separated by what an operator would do about them:
 throttle the retries did not clear, `DataUnavailableError` for a range or a
 dataset the plan does not carry, `InvalidStockCodeError` for a code that cannot
 name a listing, and `DataSourceError` for the rest.
+
+Provider error text may be retained for diagnosis, but the configured API key is
+redacted before that text can enter an application exception, stderr or the job
+log. The response body itself is never copied into an error.
 
 A source refuses to be built without an API key, before a socket is opened.
 `LazySource` defers that construction to the first fetch, which is what lets the
@@ -243,6 +264,10 @@ No analysis is written here.
 
 `charts.py`, `summary.py` and `notify.py` are the daily commands. `migrate.py`
 is run once by hand and is not in `run.sh`.
+
+Argument boundaries are rejected at parsing: chart days are zero or greater,
+with zero retaining its all-history meaning, and summary ranges are one or
+greater. Invalid values are usage errors and exit 2.
 
 ## 5. The flow of one stock
 
@@ -321,9 +346,10 @@ The API key is read from `JQUANTS_API_KEY` and from nothing else. It is refused
 if it appears in the configuration file, and its field is excluded from the
 dataclass repr so that logging a `Settings` cannot disclose it.
 
-`--data-dir` moves the history directory with it unless the history directory
-was configured on its own, so that the option moves the whole output of a run
-rather than half of it.
+`--data-dir` moves the history directory with it only when that history path was
+derived from the data directory. A history directory explicitly supplied by
+`FINANCE_HISTORY_DIR` or `paths.history_dir` remains fixed even when its value
+happened to equal the old derived default.
 
 ## 8. Error handling
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -318,8 +318,11 @@ git pull
 ./deploy.sh
 ```
 
-The virtual environment and `run.sh` are replaced; `data/` and `clf/` are not
-touched. Re-run one stock by hand as above before the next scheduled run.
+The virtual environment and `run.sh` are replaced. Existing generated data,
+model contents and stock-list contents are not overwritten. Deployment may
+create missing directories or shipped stock lists, and it reapplies ownership
+and permissions under `data/` and `clf/`. Re-run one stock by hand as above
+before the next scheduled run.
 
 ---
 

--- a/doc/VERSIONS
+++ b/doc/VERSIONS
@@ -6,8 +6,14 @@ v1.0.2 (Release Date: TBD)
 - Keep chart-only runs on stored prices, leaving fetches exclusive to
   `--update`.
 - Keep `stock_CODE.csv` to trading-day rows by omitting empty calendar gaps.
-- Reject malformed configuration values instead of silently defaulting them.
+- Reject missing or malformed configuration, non-finite request values and
+  retention windows too short for the analysis before work starts.
+- Preserve an explicitly configured history directory when `--data-dir`
+  changes the data output directory.
 - Reject malformed J-Quants data rows instead of silently discarding them.
+- Redact any echoed API key before a provider error reaches logs or stderr.
+- Reject invalid chart/summary ranges and stock-list rows missing code or name.
+- Replace generated CSV/TXT files atomically so failed writes keep good data.
 
 v1.0.1 (2026-08-26)
 -------------------

--- a/finance/cli/__init__.py
+++ b/finance/cli/__init__.py
@@ -30,6 +30,9 @@
 #  - Standard library only
 #
 #  Version History:
+#  v1.2 2026-09-12
+#       Preserve explicit history paths under --data-dir; this fixes incompatible
+#       path resolution from the prior implementation.
 #  v1.1 2026-09-09
 #       Validate command-line log levels with the shared configuration rule.
 #  v1.0 2026-08-14
@@ -87,8 +90,10 @@ def resolve_settings(arguments: argparse.Namespace) -> Settings:
         overrides["data_dir"] = data_dir
         # The history directory follows the data directory unless it was
         # configured on its own, so that --data-dir moves the whole
-        # output of a run rather than half of it.
-        if settings.history_dir == settings.data_dir / "history":
+        # output of a run rather than half of it. Provenance, not value
+        # equality, decides this: an explicit history directory that
+        # happens to equal the derived default must still stay fixed.
+        if not settings._history_dir_explicit:
             overrides["history_dir"] = data_dir / "history"
     if getattr(arguments, "log_level", None):
         overrides["log_level"] = validate_log_level(arguments.log_level)

--- a/finance/cli/charts.py
+++ b/finance/cli/charts.py
@@ -45,10 +45,10 @@
 #      the earliest the subscribed plan keeps is raised to it and the
 #      run says so, rather than being refused.
 #  - -y, --days N
-#      How many trailing rows to analyse and chart. 0 means all. The
-#      value also selects the chart: over 300 writes long_CODE.png, 60
-#      or fewer writes short_CODE.png, anything between writes
-#      chart_CODE.png.
+#      How many trailing rows to analyse and chart. 0 means all;
+#      negative values are rejected. The value also selects the chart:
+#      over 300 writes long_CODE.png, 60 or fewer writes short_CODE.png,
+#      anything between writes chart_CODE.png.
 #  - -a, --axis N
 #      1 draws the price panel alone, 2 adds the oscillator panel.
 #  - -p, --complexity N
@@ -64,6 +64,8 @@
 #  - See pyproject.toml
 #
 #  Version History:
+#  v1.2 2026-09-12
+#       Reject negative --days values instead of treating them as all history.
 #  v1.1 2026-08-24
 #       Record provider and plan provenance without embedding a mutable
 #       publication-delay claim.
@@ -111,6 +113,17 @@ SOURCE_DESCRIPTION = "J-Quants API (Free plan)"
 logger = logging.getLogger(__name__)
 
 
+def _days(value: str) -> int:
+    """ Parse --days, accepting zero or a positive integer and refusing the rest. """
+    try:
+        number = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer, got {0!r}".format(value)) from exc
+    if number < 0:
+        raise argparse.ArgumentTypeError("must not be negative, got {0}".format(number))
+    return number
+
+
 def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """ Parse the command line. """
     parser = argparse.ArgumentParser(
@@ -126,7 +139,8 @@ def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("-d", "--date", dest="startdate", help="start date as YYYY-MM-DD")
     parser.add_argument(
-        "-y", "--days", dest="days", type=int, default=DEFAULT_DAYS, help="rows to analyse"
+        "-y", "--days", dest="days", type=_days, default=DEFAULT_DAYS,
+        help="rows to analyse; 0 means all, negative is rejected",
     )
     parser.add_argument(
         "-a", "--axis", dest="axis", type=int, default=DEFAULT_AXIS, choices=(1, 2),

--- a/finance/cli/summary.py
+++ b/finance/cli/summary.py
@@ -9,7 +9,7 @@
 #  separated summary table, and optionally keep a dated copy.
 #
 #  The options are the ones bin/summary.py has always accepted. run.sh
-#  invokes this command six times with different combinations of them,
+#  invokes this command five times with different combinations of them,
 #  and each combination produces one of the files finance-dashboard
 #  reads, so the letters and their meanings are fixed.
 #
@@ -32,8 +32,8 @@
 #      Name of the summary written into the data directory. Defaults to
 #      out.csv.
 #  - -r, --range N
-#      How many rows back the change is measured over. 1 compares the
-#      last row with the one before it.
+#      How many rows back the change is measured over. Must be at least
+#      1; 1 compares the last row with the one before it.
 #  - -k, --sortkey KEY
 #      Column to sort by. Defaults to Ratio.
 #  - -a, --ascending
@@ -55,6 +55,8 @@
 #  - See pyproject.toml
 #
 #  Version History:
+#  v1.1 2026-09-12
+#       Reject non-positive --range values before aggregation.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -82,6 +84,17 @@ DEFAULT_OUTPUT = "out.csv"
 logger = logging.getLogger(__name__)
 
 
+def _span(value: str) -> int:
+    """ Parse --range, accepting an integer of 1 or more and refusing the rest. """
+    try:
+        number = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer, got {0!r}".format(value)) from exc
+    if number < 1:
+        raise argparse.ArgumentTypeError("must be at least 1, got {0}".format(number))
+    return number
+
+
 def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """ Parse the command line. """
     parser = argparse.ArgumentParser(
@@ -93,7 +106,8 @@ def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "-o", "--output", dest="output", default=DEFAULT_OUTPUT, help="output file name"
     )
     parser.add_argument(
-        "-r", "--range", dest="span", type=int, default=1, help="rows the change spans"
+        "-r", "--range", dest="span", type=_span, default=1,
+        help="rows the change spans; must be at least 1",
     )
     parser.add_argument(
         "-k", "--sortkey", dest="sortkey", default=DEFAULT_SORT_KEY, help="column to sort by"

--- a/finance/config.py
+++ b/finance/config.py
@@ -45,8 +45,9 @@
 #      environment only, never from the configuration file. The name
 #      matches the one the official J-Quants client reads, so a host
 #      that already exports it needs nothing added.
-#  - FINANCE_CONFIG: Path of the YAML configuration file. Optional.
-#      Defaults to ./config.yml when that file exists.
+#  - FINANCE_CONFIG: Path of the YAML configuration file. Optional. When
+#      set, it names an explicit file that must exist and parse as YAML.
+#      Unset, the implicit ./config.yml is used and may be absent.
 #  - FINANCE_DATA_DIR: Directory holding generated files. Defaults to
 #      ./data.
 #  - FINANCE_HISTORY_DIR: Directory holding dated summary copies.
@@ -86,6 +87,8 @@
 #  - PyYAML
 #
 #  Version History:
+#  v1.2 2026-09-12
+#       Reject invalid config sources and ranges; track explicit history paths.
 #  v1.1 2026-09-09
 #       Reject malformed sections, booleans, log levels and mail ports at load.
 #  v1.0 2026-08-14
@@ -96,6 +99,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
@@ -128,6 +132,15 @@ DEFAULT_REQUEST_INTERVAL = 1.0
 # documentation; these values are only the defaults this program uses.
 DEFAULT_DELAY_DAYS = 84
 DEFAULT_RETENTION_DAYS = 730
+
+# The shortest retention window that still fits the longest indicator
+# lookback. finance.indicators.SMA_PERIODS currently tops out at 200, and
+# this repository's own approximation of trading days in a calendar window
+# is calendar days * 5 / 7; 281 is the smallest integer for which
+# 200 < 281 / 7 * 5. This module does not import finance.indicators, so the
+# derivation is recorded here and pinned by test/test_plan_window.py rather
+# than computed at import time.
+MIN_RETENTION_DAYS = 281
 
 logger = logging.getLogger(__name__)
 
@@ -210,6 +223,12 @@ class Settings:
     mail: MailSettings = field(default_factory=MailSettings)
     jquants: JQuantsSettings = field(default_factory=JQuantsSettings)
 
+    # Not a config key or CLI option. Records whether history_dir came from
+    # an explicit FINANCE_HISTORY_DIR or paths.history_dir rather than being
+    # derived from data_dir, so that --data-dir can preserve an explicit
+    # value even when it happens to equal the derived default.
+    _history_dir_explicit: bool = field(default=False, repr=False, compare=False)
+
     def data_file(self, name: str) -> Path:
         """ Return the path of a generated file inside the data directory. """
         return self.data_dir / name
@@ -269,7 +288,13 @@ def _env(name: str) -> str | None:
 
 
 def _load_file(path: Path) -> dict[str, Any]:
-    """ Load a YAML configuration file, returning an empty mapping when absent. """
+    """
+    Load a YAML configuration file, returning an empty mapping when absent.
+
+    Raises:
+        ConfigurationError: The file exists but could not be read, is not
+            valid YAML, or is not a mapping at the top level.
+    """
     if not path.is_file():
         return {}
     try:
@@ -279,6 +304,8 @@ def _load_file(path: Path) -> dict[str, Any]:
     try:
         with open(path, encoding="utf-8") as handle:
             loaded = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        raise ConfigurationError("Configuration file is not valid YAML: {0}".format(path)) from exc
     except (OSError, ValueError) as exc:
         raise ConfigurationError("Configuration file could not be read: {0}".format(path)) from exc
     if loaded is None:
@@ -344,19 +371,48 @@ def _as_positive_int(value: Any, name: str) -> int:
     return number
 
 
+def _as_retention_days(value: Any, name: str) -> int:
+    """
+    Interpret a configuration value as a retention window of at least
+    MIN_RETENTION_DAYS days.
+
+    A window shorter than that cannot hold the longest indicator lookback
+    this repository currently requires; see MIN_RETENTION_DAYS.
+    """
+    number = _as_positive_int(value, name)
+    if number < MIN_RETENTION_DAYS:
+        raise ConfigurationError(
+            "{0} must be at least {1} days, got {2}".format(name, MIN_RETENTION_DAYS, number)
+        )
+    return number
+
+
 def _as_positive_float(value: Any, name: str) -> float:
-    """ Interpret a configuration value as a number above zero. """
+    """
+    Interpret a configuration value as a finite number above zero.
+
+    nan and +/-inf are refused: a naive comparison against zero lets both
+    through, since neither satisfies "not greater than zero".
+    """
     number = _as_float(value, name)
-    if number <= 0:
-        raise ConfigurationError("{0} must be greater than zero, got {1}".format(name, number))
+    if not math.isfinite(number) or number <= 0:
+        raise ConfigurationError(
+            "{0} must be a finite number greater than zero, got {1}".format(name, number)
+        )
     return number
 
 
 def _as_non_negative(value: Any, name: str) -> float:
-    """ Interpret a configuration value as a number of zero or more. """
+    """
+    Interpret a configuration value as a finite number of zero or more.
+
+    nan and +/-inf are refused; see _as_positive_float.
+    """
     number = _as_float(value, name)
-    if number < 0:
-        raise ConfigurationError("{0} must not be negative, got {1}".format(name, number))
+    if not math.isfinite(number) or number < 0:
+        raise ConfigurationError(
+            "{0} must be a finite number that is not negative, got {1}".format(name, number)
+        )
     return number
 
 
@@ -408,14 +464,43 @@ def _resolve(value: Any) -> Path:
     return Path(os.path.expanduser(str(value))).resolve()
 
 
+def _resolve_config_path(config_file: str | os.PathLike[str] | None) -> Path:
+    """
+    Decide which configuration file to read.
+
+    An explicit source -- the config_file argument, or failing that a
+    non-blank FINANCE_CONFIG -- must name a regular file that exists. With
+    neither, the implicit ./config.yml is used and may be absent, which is
+    read as an empty configuration.
+
+    Raises:
+        ConfigurationError: An explicit source was given but is not a
+            regular file.
+    """
+    if config_file is not None:
+        path = Path(config_file)
+        if not path.is_file():
+            raise ConfigurationError("Configuration file does not exist: {0}".format(config_file))
+        return path
+    env_value = _env("CONFIG")
+    if env_value is not None:
+        path = Path(env_value)
+        if not path.is_file():
+            raise ConfigurationError("Configuration file does not exist: {0}".format(env_value))
+        return path
+    return Path("config.yml")
+
+
 def load_settings(config_file: str | os.PathLike[str] | None = None) -> Settings:
     """
     Resolve settings from the environment and the configuration file.
 
     Args:
-        config_file: Explicit path of a YAML file. When omitted,
-            FINANCE_CONFIG is used, and failing that ./config.yml when
-            it exists.
+        config_file: Explicit path of a YAML file. When omitted, a
+            non-blank FINANCE_CONFIG is used instead. Either one must name
+            a file that exists and parses as YAML. With neither given, the
+            implicit ./config.yml is read and may be absent, in which case
+            defaults are used.
 
     Returns:
         A validated Settings instance.
@@ -423,9 +508,7 @@ def load_settings(config_file: str | os.PathLike[str] | None = None) -> Settings
     Raises:
         ConfigurationError: A value is present but cannot be used.
     """
-    path = Path(config_file) if config_file else Path(_env("CONFIG") or "config.yml")
-    if config_file and not Path(config_file).is_file():
-        raise ConfigurationError("Configuration file does not exist: {0}".format(config_file))
+    path = _resolve_config_path(config_file)
     config = _load_file(path)
 
     paths = _section(config, "paths")
@@ -436,9 +519,9 @@ def load_settings(config_file: str | os.PathLike[str] | None = None) -> Settings
     jquants_section = _section(config, "jquants")
 
     data_dir = _resolve(_first(_env("DATA_DIR"), paths.get("data_dir"), "data"))
-    history_dir = _resolve(
-        _first(_env("HISTORY_DIR"), paths.get("history_dir"), data_dir / "history")
-    )
+    explicit_history_dir = _first(_env("HISTORY_DIR"), paths.get("history_dir"))
+    history_dir_explicit = explicit_history_dir is not None
+    history_dir = _resolve(explicit_history_dir if history_dir_explicit else data_dir / "history")
     model_dir = _resolve(_first(_env("MODEL_DIR"), paths.get("model_dir"), "clf"))
 
     start_date = str(_first(_env("START_DATE"), pipeline.get("start_date"), "") or "")
@@ -459,6 +542,7 @@ def load_settings(config_file: str | os.PathLike[str] | None = None) -> Settings
         ),
         mail=_load_mail(mail_section),
         jquants=_load_jquants(jquants_section),
+        _history_dir_explicit=history_dir_explicit,
     )
     logger.debug("Resolved settings from %s", path if path.is_file() else "defaults")
     return settings
@@ -504,7 +588,7 @@ def _load_jquants(section: dict[str, Any]) -> JQuantsSettings:
             _first(_env("JQUANTS_DELAY_DAYS"), section.get("delay_days"), DEFAULT_DELAY_DAYS),
             "jquants delay_days",
         ),
-        retention_days=_as_positive_int(
+        retention_days=_as_retention_days(
             _first(
                 _env("JQUANTS_RETENTION_DAYS"),
                 section.get("retention_days"),

--- a/finance/datasources/jquants.py
+++ b/finance/datasources/jquants.py
@@ -54,6 +54,10 @@
 #  A non-object item in the response data list is likewise refused rather than
 #  silently discarded.
 #
+#  A provider error message may echo back part of the request, which is why
+#  the configured API key is redacted from it before the text can enter an
+#  exception, stderr or the job log; see _message().
+#
 #  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
@@ -64,6 +68,8 @@
 #  - pandas, requests
 #
 #  Version History:
+#  v1.2 2026-09-12
+#       Redact an echoed API key from provider error messages.
 #  v1.1 2026-09-09
 #       Refuse non-object response rows instead of silently discarding them.
 #  v1.0 2026-08-14
@@ -380,14 +386,19 @@ class JQuantsSource:
         except (TypeError, ValueError):
             return None
 
-    @staticmethod
-    def _message(response: object) -> str:
+    def _message(self, response: object) -> str:
         """
         Return the message the API reported, and nothing else.
 
         Only the message member is taken. The body is never logged or
         re-raised whole: it carries market data, and an error path is no
         place to copy that into a log file.
+
+        A provider is free to echo request details back in an error
+        message, so the configured API key -- if any -- is redacted from
+        the message before it is truncated, and only the sanitized text is
+        returned. Truncating first and redacting after would let a key
+        that straddles the cutoff survive intact.
         """
         try:
             body = response.json()
@@ -395,8 +406,11 @@ class JQuantsSource:
             return ""
         if not isinstance(body, dict):
             return ""
-        message = body.get("message") or ""
-        return str(message)[:200]
+        message = str(body.get("message") or "")
+        key = self.settings.api_key
+        if key:
+            message = message.replace(key, "[REDACTED]")
+        return message[:200]
 
     def _decode(self, response: object) -> dict[str, Any]:
         """

--- a/finance/stocklist.py
+++ b/finance/stocklist.py
@@ -32,6 +32,8 @@
 #  - Standard library only
 #
 #  Version History:
+#  v1.1 2026-09-12
+#       Reject stock-list records with an empty required code or name.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -77,7 +79,8 @@ def read_stock_list(path: str | os.PathLike[str]) -> list[StockEntry]:
 
     Raises:
         StorageError: The file does not exist or cannot be read.
-        DataFormatError: A non-blank line carries fewer than two fields.
+        DataFormatError: A non-blank line carries fewer than two fields, or
+            has an empty required code or name.
     """
     target = Path(path)
     try:
@@ -90,16 +93,27 @@ def read_stock_list(path: str | os.PathLike[str]) -> list[StockEntry]:
 
     entries: list[StockEntry] = []
     for number, fields in enumerate(rows, start=1):
-        if not fields or not fields[0].strip():
+        # A true blank line: an empty CSV row, or a single whitespace-only
+        # field. A row such as ",トヨタ" or "7203," has content and is
+        # refused below rather than treated as blank.
+        if not fields:
+            continue
+        if len(fields) == 1 and not fields[0].strip():
             continue
         if len(fields) < 2:
             raise DataFormatError(
                 "{0} line {1}: expected at least a code and a name".format(target, number)
             )
+        code = fields[0].strip()
+        if not code:
+            raise DataFormatError("{0} line {1}: code must not be empty".format(target, number))
+        name = fields[1].strip()
+        if not name:
+            raise DataFormatError("{0} line {1}: name must not be empty".format(target, number))
         entries.append(
             StockEntry(
-                code=fields[0].strip(),
-                name=fields[1].strip(),
+                code=code,
+                name=name,
                 fullname=fields[2].strip() if len(fields) > 2 else "",
             )
         )

--- a/finance/storage.py
+++ b/finance/storage.py
@@ -18,6 +18,16 @@
 #  layers above it own the layout and a test can point it at a temporary
 #  directory.
 #
+#  The generated CSV and data_source.txt writers replace their target
+#  atomically: content is completed in a sibling temporary file first, and
+#  only a successful write is moved onto the target with os.replace(). A
+#  failure -- while writing, while carrying over the existing target's
+#  ownership and mode, or while replacing -- leaves the last good target
+#  untouched and cleans up the temporary file. ModelStore.save() and the PNG
+#  writer in finance/charts.py are outside this: models tolerate an unreadable
+#  file by retraining, and chart regeneration always follows a successful CSV
+#  write.
+#
 #  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
 #  License: The GPL version 3, or LGPL version 3 (Dual License).
@@ -28,6 +38,8 @@
 #  - pandas
 #
 #  Version History:
+#  v1.1 2026-09-12
+#       Atomically replace generated CSV/TXT output after complete writes.
 #  v1.0 2026-08-14
 #       Initial release.
 #
@@ -38,6 +50,9 @@ from __future__ import annotations
 import logging
 import os
 import pickle
+import stat
+import uuid
+from collections.abc import Callable
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -102,6 +117,74 @@ def ensure_directory(path: str | os.PathLike[str]) -> Path:
     return target
 
 
+def _create_temp_file(target: Path) -> Path:
+    """
+    Create an empty, uniquely named sibling of target and return its path.
+
+    Created with O_CREAT | O_EXCL at mode 0o666, the same request every
+    regular file creation makes; the umask in effect, not a restrictive
+    hardcoded mode, is what narrows it. A new file written this way and
+    then moved onto an absent target keeps that mode, rather than the
+    narrower default a general-purpose temp file helper would leave it at.
+    """
+    while True:
+        candidate = target.with_name("{0}.{1}.tmp".format(target.name, uuid.uuid4().hex))
+        try:
+            fd = os.open(str(candidate), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+        except FileExistsError:
+            continue
+        os.close(fd)
+        return candidate
+
+
+def _preserve_metadata(target: Path, temp_path: Path) -> None:
+    """ Carry an existing target's mode, owner and group onto its replacement. """
+    try:
+        info = target.stat()
+    except FileNotFoundError:
+        return
+    os.chmod(temp_path, stat.S_IMODE(info.st_mode))
+    os.chown(temp_path, info.st_uid, info.st_gid)
+
+
+def _discard_temp_file(temp_path: Path) -> None:
+    """ Remove a temporary file left behind by a write that did not complete. """
+    try:
+        temp_path.unlink()
+    except OSError:
+        pass
+
+
+def _replace_atomically(target: Path, write: Callable[[Path], None]) -> None:
+    """
+    Write target's replacement into a sibling temporary file, then move it
+    into place with a single atomic os.replace().
+
+    write is called with the temporary file's path and must write the
+    complete content to it. Nothing about target is touched until the
+    write, the metadata carry-over and the replace have all succeeded, so
+    a failure at any point leaves the last good target exactly as it was.
+
+    Raises:
+        StorageError: The write, the metadata carry-over or the replace
+            failed with an OSError.
+    """
+    ensure_directory(target.parent)
+    temp_path = _create_temp_file(target)
+    try:
+        write(temp_path)
+        _preserve_metadata(target, temp_path)
+        os.replace(temp_path, target)
+    except OSError as exc:
+        _discard_temp_file(temp_path)
+        raise StorageError("File could not be written: {0}".format(target)) from exc
+    except BaseException:
+        # An unexpected failure is not collapsed into StorageError, but the
+        # temporary file is still cleaned up and target is still untouched.
+        _discard_temp_file(temp_path)
+        raise
+
+
 def read_price_csv(path: str | os.PathLike[str]) -> pd.DataFrame:
     """
     Read a price or indicator CSV indexed by date.
@@ -132,6 +215,9 @@ def write_price_csv(frame: pd.DataFrame, path: str | os.PathLike[str]) -> None:
     read to the dashboard as a stock that has lost its history, which is
     worse than one that was not refreshed today.
 
+    The write is atomic: a failure partway through leaves the existing
+    file exactly as it was, rather than truncated or half rewritten.
+
     Raises:
         StorageError: The file cannot be written.
     """
@@ -139,11 +225,11 @@ def write_price_csv(frame: pd.DataFrame, path: str | os.PathLike[str]) -> None:
         logger.warning("Refusing to write an empty frame to %s", path)
         return
     target = Path(path)
-    ensure_directory(target.parent)
-    try:
-        frame.to_csv(target, sep=PRICE_SEPARATOR, index_label=PRICE_INDEX_LABEL)
-    except OSError as exc:
-        raise StorageError("File could not be written: {0}".format(target)) from exc
+
+    def write(temp_path: Path) -> None:
+        frame.to_csv(temp_path, sep=PRICE_SEPARATOR, index_label=PRICE_INDEX_LABEL)
+
+    _replace_atomically(target, write)
     logger.debug("Wrote %d rows to %s", len(frame), target)
 
 
@@ -151,15 +237,18 @@ def write_summary_csv(frame: pd.DataFrame, path: str | os.PathLike[str]) -> None
     """
     Write a summary table in the tab separated format the dashboard reads.
 
+    The write is atomic: a failure partway through leaves the existing
+    file exactly as it was, rather than truncated or half rewritten.
+
     Raises:
         StorageError: The file cannot be written.
     """
     target = Path(path)
-    ensure_directory(target.parent)
-    try:
-        frame.to_csv(target, sep=SUMMARY_SEPARATOR, index_label=SUMMARY_INDEX_LABEL)
-    except OSError as exc:
-        raise StorageError("File could not be written: {0}".format(target)) from exc
+
+    def write(temp_path: Path) -> None:
+        frame.to_csv(temp_path, sep=SUMMARY_SEPARATOR, index_label=SUMMARY_INDEX_LABEL)
+
+    _replace_atomically(target, write)
     logger.debug("Wrote %d rows to %s", len(frame), target)
 
 
@@ -216,6 +305,9 @@ def write_data_source(
             substituting the run date would make older or unknown data
             look more current than it is.
 
+    The write is atomic: a failure partway through leaves the existing
+    file exactly as it was, rather than truncated or half rewritten.
+
     Raises:
         StorageError: The file cannot be written.
     """
@@ -225,12 +317,13 @@ def write_data_source(
         "last_trading_day": last_trading_day.isoformat() if last_trading_day else "",
     }
     lines = ["{0}\t{1}".format(key, values[key]) for key in DATA_SOURCE_KEYS]
+    content = "\n".join(lines) + "\n"
     target = Path(path)
-    ensure_directory(target.parent)
-    try:
-        target.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    except OSError as exc:
-        raise StorageError("File could not be written: {0}".format(target)) from exc
+
+    def write(temp_path: Path) -> None:
+        temp_path.write_text(content, encoding="utf-8")
+
+    _replace_atomically(target, write)
     logger.debug("Wrote %s", target)
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -33,6 +33,9 @@
 #    API key needed.
 #  - A chart-only list run continues past a stock with no stored file.
 #  - An unknown command-line log level fails as a configuration error.
+#  - A negative --days or a non-positive --range exits 2.
+#  - --data-dir moves a derived history directory but preserves an
+#    explicitly configured one.
 #
 #  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
@@ -56,7 +59,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
-from finance.cli import EXIT_FAILURE, EXIT_SUCCESS, EXIT_USAGE
+from finance.cli import EXIT_FAILURE, EXIT_SUCCESS, EXIT_USAGE, resolve_settings
 from finance.cli import charts as charts_cli
 from finance.cli import migrate as migrate_cli
 from finance.cli import notify as notify_cli
@@ -178,6 +181,19 @@ def test_an_invalid_value_exits_two(argv):
     assert raised.value.code == EXIT_USAGE
 
 
+def test_charts_rejects_negative_days():
+    with pytest.raises(SystemExit) as raised:
+        charts_cli.parse_arguments(["-y", "-1"])
+    assert raised.value.code == EXIT_USAGE
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_summary_rejects_non_positive_range(value):
+    with pytest.raises(SystemExit) as raised:
+        summary_cli.parse_arguments(["-r", value])
+    assert raised.value.code == EXIT_USAGE
+
+
 def test_charts_without_a_code_or_a_list_fails(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
     status = charts_cli.main(["--data-dir", str(tmp_path)])
@@ -226,6 +242,40 @@ def test_summary_with_an_unknown_sort_key_fails(tmp_path, monkeypatch, capsys):
 # --------------------------------------------------------------------
 # Output location
 # --------------------------------------------------------------------
+
+
+def test_data_dir_override_moves_derived_history_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    new_dir = tmp_path / "new"
+    arguments = charts_cli.parse_arguments(["--data-dir", str(new_dir)])
+    settings = resolve_settings(arguments)
+
+    assert settings.data_dir == new_dir.resolve()
+    assert settings.history_dir == new_dir.resolve() / "history"
+
+
+def test_data_dir_override_preserves_explicit_history_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    old_dir = tmp_path / "old"
+    old_dir.mkdir()
+    config = tmp_path / "config.yml"
+    config.write_text(
+        "paths:\n"
+        "  data_dir: {0}\n"
+        "  history_dir: {0}/history\n".format(old_dir),
+        encoding="utf-8",
+    )
+    new_dir = tmp_path / "new"
+    arguments = charts_cli.parse_arguments(
+        ["--config", str(config), "--data-dir", str(new_dir)]
+    )
+    settings = resolve_settings(arguments)
+
+    # The explicit history directory happens to equal what would have been
+    # derived from the old data directory. Provenance, not that equality,
+    # is what must keep it fixed under --data-dir.
+    assert settings.data_dir == new_dir.resolve()
+    assert settings.history_dir == (old_dir / "history").resolve()
 
 
 def test_summary_writes_where_data_dir_points(tmp_path, monkeypatch, indicator_fixture):

--- a/test/test_datasources.py
+++ b/test/test_datasources.py
@@ -42,6 +42,8 @@
 #  - An empty response is a normal answer, not an error.
 #  - An unknown source name is refused.
 #  - No error message and no log record carries the API key.
+#  - An API key echoed back by the provider is redacted rather than
+#    suppressing the rest of the message.
 #
 #  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
@@ -403,10 +405,16 @@ def test_an_invalid_code_fails_before_a_request():
 
 
 def test_no_error_message_carries_the_api_key():
-    session = FakeSession([FakeResponse(status_code=401, body={"message": "denied"})])
+    session = FakeSession(
+        [FakeResponse(status_code=401, body={"message": "denied {0}".format(API_KEY)})]
+    )
     with pytest.raises(AuthenticationError) as caught:
         source(session).fetch("7203", START, END)
-    assert API_KEY not in str(caught.value)
+
+    message = str(caught.value)
+    assert API_KEY not in message
+    assert "[REDACTED]" in message
+    assert "denied" in message
 
 
 def test_no_log_record_carries_the_api_key(caplog):

--- a/test/test_plan_window.py
+++ b/test/test_plan_window.py
@@ -28,6 +28,7 @@
 #  - Stored data reaching the newest published date is not re-requested.
 #  - Staleness is measured against the newest published date.
 #  - The lookback the longest indicator needs fits inside the window.
+#  - The configured minimum retention window covers that same lookback.
 #
 #  Author: id774 (More info: https://id774.net)
 #  Source Code: https://github.com/id774/finance
@@ -52,7 +53,7 @@ from datetime import date, timedelta
 import pandas as pd
 
 from finance.analysis import Analysis, AnalysisRequest
-from finance.config import JQuantsSettings
+from finance.config import MIN_RETENTION_DAYS, JQuantsSettings
 from finance.indicators import SMA_PERIODS
 from finance.reporting import SummaryRequest, build_summary
 from finance.storage import write_price_csv
@@ -169,3 +170,13 @@ def test_the_longest_lookback_fits_inside_the_window():
     """
     trading_days = (TEST_PLAN.retention_days / 7) * 5
     assert max(SMA_PERIODS) < trading_days
+
+
+def test_minimum_retention_window_covers_the_longest_required_lookback():
+    """
+    MIN_RETENTION_DAYS must be the smallest window that still fits the
+    longest indicator lookback, so a configuration right at the minimum
+    is usable and one day short is provably not.
+    """
+    assert max(SMA_PERIODS) < (MIN_RETENTION_DAYS / 7) * 5
+    assert not max(SMA_PERIODS) < ((MIN_RETENTION_DAYS - 1) / 7) * 5

--- a/test/test_storage_and_config.py
+++ b/test/test_storage_and_config.py
@@ -19,9 +19,17 @@
 #  - A round trip through the CSV writers preserves values and index.
 #  - An empty frame is not written over a good file.
 #  - A missing or malformed file is reported as the right error.
+#  - A failed CSV, summary or data_source write preserves the existing file.
+#  - Atomic replacement preserves an existing file's mode; a new file gets
+#    the regular creation mode rather than a restrictive temp file default.
 #  - Models round trip, and a corrupt one reads as absent.
+#  - A stock list entry with an empty required code or name is refused.
 #  - Defaults, environment, file and precedence between them.
 #  - Malformed dates, booleans, sections, log levels and mail ports are refused.
+#  - An explicit configuration source that is absent or not valid YAML is
+#    refused; the implicit default may still be absent.
+#  - Non-finite J-Quants numeric settings and a too-short retention window
+#    are refused; the minimum retention window is accepted.
 #  - The mail host guard.
 #
 #  Author: id774 (More info: https://id774.net)
@@ -43,6 +51,8 @@
 
 from __future__ import annotations
 
+import os
+import stat
 from datetime import date
 from pathlib import Path
 
@@ -147,6 +157,100 @@ def test_merge_frames_joins_on_the_index(raw_prices):
 
 
 # --------------------------------------------------------------------
+# atomic writes
+# --------------------------------------------------------------------
+
+
+def _fail_after_partial_write(monkeypatch, patched, attribute):
+    """
+    Make an attribute write a partial temporary file then raise OSError.
+
+    Used to simulate a write that fails after the temporary file already
+    carries some bytes, so a test can assert the existing target survives.
+    """
+    original = getattr(patched, attribute)
+
+    def broken(self, *args, **kwargs):
+        target = args[0] if args else kwargs.get("path_or_buf")
+        Path(target).write_text("partial", encoding="utf-8")
+        raise OSError("disk full")
+
+    monkeypatch.setattr(patched, attribute, broken)
+    return original
+
+
+def test_failed_price_write_preserves_existing_file(settings, raw_prices, monkeypatch):
+    path = settings.data_file("stock_TEST.csv")
+    original = "Date,Open\n2015-01-01,1\n"
+    path.write_text(original, encoding="utf-8")
+
+    _fail_after_partial_write(monkeypatch, pd.DataFrame, "to_csv")
+    with pytest.raises(StorageError):
+        storage.write_price_csv(raw_prices, path)
+
+    assert path.read_text(encoding="utf-8") == original
+    assert list(path.parent.glob("*.tmp")) == []
+
+
+def test_failed_summary_write_preserves_existing_file(settings, monkeypatch):
+    path = settings.data_file("summary.csv")
+    original = "Code\tName\n7203\tトヨタ\n"
+    path.write_text(original, encoding="utf-8")
+
+    frame = pd.DataFrame({"Open": [100]}, index=["1111"])
+    _fail_after_partial_write(monkeypatch, pd.DataFrame, "to_csv")
+    with pytest.raises(StorageError):
+        storage.write_summary_csv(frame, path)
+
+    assert path.read_text(encoding="utf-8") == original
+    assert list(path.parent.glob("*.tmp")) == []
+
+
+def test_failed_data_source_write_preserves_existing_file(settings, monkeypatch):
+    path = settings.data_file("data_source.txt")
+    original = "source\told\n"
+    path.write_text(original, encoding="utf-8")
+
+    real_write_text = Path.write_text
+
+    def broken_write_text(self, content, *args, **kwargs):
+        if self.name.endswith(".tmp"):
+            real_write_text(self, "partial", *args, **kwargs)
+            raise OSError("disk full")
+        return real_write_text(self, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", broken_write_text)
+    with pytest.raises(StorageError):
+        storage.write_data_source(
+            path, "J-Quants API (Free plan)", date(2026, 8, 14), None
+        )
+
+    assert path.read_text(encoding="utf-8") == original
+    assert list(path.parent.glob("*.tmp")) == []
+
+
+def test_atomic_replacement_preserves_existing_mode(settings):
+    path = settings.data_file("data_source.txt")
+    path.write_text("source\told\n", encoding="utf-8")
+    os.chmod(path, 0o640)
+
+    storage.write_data_source(path, "J-Quants API (Free plan)", date(2026, 8, 14), None)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+
+
+def test_new_atomic_file_uses_regular_creation_mode(settings):
+    path = settings.data_file("data_source.txt")
+    old_umask = os.umask(0o027)
+    try:
+        storage.write_data_source(path, "J-Quants API (Free plan)", date(2026, 8, 14), None)
+    finally:
+        os.umask(old_umask)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o640
+
+
+# --------------------------------------------------------------------
 # stocklist
 # --------------------------------------------------------------------
 
@@ -191,6 +295,20 @@ def test_an_empty_stock_list_is_refused(tmp_path):
     path = tmp_path / "stocks.txt"
     path.write_text("\n\n", encoding="utf-8")
     with pytest.raises(DataFormatError, match="empty"):
+        read_stock_list(path)
+
+
+def test_a_stock_list_with_an_empty_code_is_refused(tmp_path):
+    path = tmp_path / "stocks.txt"
+    path.write_text(",トヨタ\n", encoding="utf-8")
+    with pytest.raises(DataFormatError, match="code must not be empty"):
+        read_stock_list(path)
+
+
+def test_a_stock_list_with_an_empty_name_is_refused(tmp_path):
+    path = tmp_path / "stocks.txt"
+    path.write_text("7203,\n", encoding="utf-8")
+    with pytest.raises(DataFormatError, match="name must not be empty"):
         read_stock_list(path)
 
 
@@ -354,12 +472,51 @@ def test_a_named_configuration_file_must_exist(tmp_path, monkeypatch):
         load_settings(tmp_path / "absent.yml")
 
 
+def test_an_environment_named_configuration_file_must_exist(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FINANCE_CONFIG", str(tmp_path / "absent.yml"))
+    with pytest.raises(ConfigurationError, match="does not exist"):
+        load_settings()
+
+
 def test_a_configuration_file_that_is_not_a_mapping_is_refused(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     config = tmp_path / "config.yml"
     config.write_text("- one\n- two\n", encoding="utf-8")
     with pytest.raises(ConfigurationError, match="not a mapping"):
         load_settings(config)
+
+
+def test_malformed_yaml_is_reported_as_configuration_error(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = tmp_path / "config.yml"
+    config.write_text("paths: [\n", encoding="utf-8")
+    with pytest.raises(ConfigurationError, match="valid YAML"):
+        load_settings(config)
+
+
+@pytest.mark.parametrize(
+    "env_name", ["FINANCE_JQUANTS_TIMEOUT", "FINANCE_JQUANTS_REQUEST_INTERVAL"]
+)
+@pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+def test_non_finite_jquants_numbers_are_refused(tmp_path, monkeypatch, env_name, value):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(env_name, value)
+    with pytest.raises(ConfigurationError, match="finite"):
+        load_settings()
+
+
+def test_retention_window_too_short_is_refused(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FINANCE_JQUANTS_RETENTION_DAYS", "280")
+    with pytest.raises(ConfigurationError, match="281"):
+        load_settings()
+
+
+def test_minimum_retention_window_is_accepted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("FINANCE_JQUANTS_RETENTION_DAYS", "281")
+    assert load_settings().jquants.retention_days == 281
 
 
 def test_start_date_is_parsed(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- An explicit `--config`/`FINANCE_CONFIG` file that does not exist now fails
  as a `ConfigurationError` instead of silently falling back to defaults.
- Malformed YAML is reported as `ConfigurationError` ("...not valid YAML...")
  instead of an unhandled `yaml.YAMLError` traceback.
- `jquants.timeout`/`request_interval` reject `nan`/`inf`/`-inf` via
  `math.isfinite()`; `retention_days` now has a `MIN_RETENTION_DAYS = 281`
  floor, derived from `max(SMA_PERIODS) == 200` and pinned by
  `test/test_plan_window.py`.
- `Settings` tracks whether `history_dir` was explicitly configured
  (`FINANCE_HISTORY_DIR` / `paths.history_dir`). `--data-dir` now preserves
  an explicit history directory by provenance rather than by comparing it
  to the derived default value.
- `finance-charts -y/--days` rejects negative values (usage error, exit 2);
  `finance-summary -r/--range` rejects values below 1.
- `finance/stocklist.py` now refuses a stock-list record with an empty
  required code or name (`DataFormatError`) instead of silently skipping it;
  only a true blank line (an empty CSV row, or a single whitespace-only
  field) is skipped.
- `finance/datasources/jquants.py::_message()` redacts the configured
  API key (`str.replace` on every occurrence) from a provider error message
  before truncation, so an echoed key cannot reach an exception, stderr or
  the job log.
- `finance/storage.py` writes `stock_CODE.csv`, `ti_CODE.csv`, summary
  tables and `data_source.txt` atomically: content is completed in a
  sibling temporary file (created at mode `0o666 & umask`) and moved onto
  the target with `os.replace()` only after the write succeeds; an existing
  target's mode/uid/gid are carried onto the replacement, and a failure at
  any point leaves the last good target untouched. `ModelStore.save()` and
  the PNG writer are unchanged.
- Documentation corrections: README/BASIC_DESIGN/DEPLOYMENT/config.yml.sample
  wording brought in line with the above, the stale "touches neither data/
  nor clf/" deployment claim removed, the testing-group and command-count
  text corrected, and `doc/VERSIONS`' unreleased v1.0.2 entry consolidated
  to the final state.

## Compatibility

- Valid configuration precedence, defaults and the absent-implicit-
  `./config.yml` behavior are unchanged.
- Valid CLI option names, defaults and `-y 0` (all-history) meaning are
  unchanged.
- Generated file schema, separators, index labels, key order and every
  formula (indicators, models, aggregation ratio) are unchanged.
- Chart prefix thresholds and chart-only no-fetch behavior are unchanged.
- `cron.d/`, `run.sh` and `deploy.sh` runtime behavior are unchanged (not
  modified).
- Dependency set is unchanged; no `pyproject.toml` change, no new
  third-party import.
- The default test suite still makes no network request and needs no API
  key.

## Version

- Repository release version remains candidate `1.0.2` (`pyproject.toml`
  and `finance.__version__` unchanged).
- `doc/VERSIONS` top entry remains `v1.0.2 (Release Date: TBD)`.
- File-level module versions bumped: `finance/config.py` v1.2,
  `finance/cli/__init__.py` v1.2, `finance/cli/charts.py` v1.2,
  `finance/cli/summary.py` v1.1, `finance/stocklist.py` v1.1,
  `finance/datasources/jquants.py` v1.2, `finance/storage.py` v1.1. Test
  modules were not version-bumped (assertions/coverage only).

## Validation (actual results)

- `pytest`: 513 passed, 2 deselected (integration), 1 pre-existing warning.
- `ruff check .`: All checks passed!
- `sh -n run.sh`: OK
- `sh -n deploy.sh`: OK
- `git diff --check`: no whitespace errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzJ43B843Qb2NNM2TZ1aYd